### PR TITLE
When doing query signing, move the security token to the query string…

### DIFF
--- a/source/aws_signing.c
+++ b/source/aws_signing.c
@@ -1649,6 +1649,7 @@ int aws_signing_build_authorization_value(struct aws_signing_state_aws *state) {
         AWS_ZERO_STRUCT(uri_encoded_buf);
 
         int error_code = AWS_OP_ERR;
+        /* if we're doing query signing, the session token goes in the query string (uri encoded), not the headers */
         if (s_is_query_param_auth(state->config->algorithm)) {
             property_list_name = g_aws_http_query_params_property_list_name;
             error_code = aws_byte_buf_init(&uri_encoded_buf, state->allocator, session_token.len);
@@ -1657,6 +1658,7 @@ int aws_signing_build_authorization_value(struct aws_signing_state_aws *state) {
                 goto cleanup;
             }
 
+            /* uri encode it */
             error_code = aws_byte_buf_append_encoding_uri_param(&uri_encoded_buf, &session_token);
             if (error_code) {
                 aws_byte_buf_clean_up(&uri_encoded_buf);


### PR DESCRIPTION
… instead of a header.

Here's the desired (and now successful call to aws iot):
```
GET /mqtt?X-Amz-Algorithm=AWS4-HMAC-SHA256&X-Amz-Credential=ASIARZKWFHMPOMLFNUC6%2F20191029%2Fus-east-1%2Fiotdevicegateway%2Faws4_request&X-Amz-Date=20191029T180332Z&X-Amz-SignedHeaders=host&X-Amz-Signature=35e954cfbbf5709bf0a09774be2912c96ab96855435bd97bbc32706822243a3c&X-Amz-Security-Token=FQoGZXIvYXdzELP%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaDHpxS%2F9FRfng5%2BDyCCLvARUHCpfVvdjT6hPYS1NKzBFxe%2FoY%2F5fAO%2BnLq72rnY8q0C%2B6PNVhuEGybT9%2FvfMuRvZljEbh6kh6n85XsvnLYxSaEimLRTovP01P3X%2Bh%2BCLGEfgVbQ2zbgNb8507x7iFRFmWr0GIND27V9OW%2FB2%2FIMKyG9X23%2BDDHFrWzGOb98tAdZWDeRsVm9tWzvjcWdZphYCI72SqGxC3Gx9DCgkWj9ZmjyP17Tn%2BQQOpZvmkUoWoNlkY1ONXxzZIa9CBg62xJFUeKKRtsc2HiTvqHaIo6NaQhM5OVKoK6lYoSTHkZF4Usn%2BZ2qZ1LSYgQJeOAtUoKNrv4e0F HTTP/1.1
Host: a16523t7iy5uyg-ats.iot.us-east-1.amazonaws.com
Upgrade: websocket
Connection: Upgrade
Sec-WebSocket-Key: rMmPrCbj4PuspGl8YdypfA==
Sec-WebSocket-Version: 13
Sec-WebSocket-Protocol: mqtt
X-Amz-Date: 20191029T180332Z

HTTP/1.1 101 Switching Protocols
content-length: 0
upgrade: websocket
connection: upgrade
sec-websocket-accept: tzFIAdq5hJWLI+pfcblnSeauNF0=
sec-websocket-protocol: mqtt
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
