### PR TITLE
Async Signer

### DIFF
--- a/include/aws/auth/private/aws_signing.h
+++ b/include/aws/auth/private/aws_signing.h
@@ -17,6 +17,7 @@
  */
 
 #include <aws/auth/auth.h>
+#include <aws/auth/signer.h>
 
 #include <aws/common/byte_buf.h>
 #include <aws/common/hash_table.h>
@@ -41,7 +42,11 @@ struct aws_signing_state_aws {
 
     const struct aws_signable *signable;
     const struct aws_signing_config_aws *config;
-    struct aws_signing_result *result;
+    aws_signer_signing_complete_fn *on_complete;
+    void *userdata;
+
+    struct aws_signing_result result;
+    struct aws_credentials *credentials;
 
     /* persistent, constructed values that are either/or
      *  (1) consumed by later stages of the signing process,
@@ -60,15 +65,15 @@ struct aws_signing_state_aws {
 AWS_EXTERN_C_BEGIN
 
 AWS_AUTH_API
-int aws_signing_state_init(
-    struct aws_signing_state_aws *state,
+struct aws_signing_state_aws *aws_signing_state_new(
     struct aws_allocator *allocator,
     const struct aws_signing_config_aws *context,
     const struct aws_signable *signable,
-    struct aws_signing_result *result);
+    aws_signer_signing_complete_fn *on_complete,
+    void *userdata);
 
 AWS_AUTH_API
-void aws_signing_state_clean_up(struct aws_signing_state_aws *state);
+void aws_signing_state_destroy(struct aws_signing_state_aws *state);
 
 /*
  * A set of functions that together performs the AWS signing process based

--- a/include/aws/auth/signer.h
+++ b/include/aws/auth/signer.h
@@ -24,11 +24,20 @@
 struct aws_signable;
 struct aws_signer;
 
+/**
+ * Gets called by the signer when the signing is complete.
+ *
+ * Note that result will be destroyed after this function returns, so either copy it,
+ * or do all necessary adjustments inside the callback.
+ */
+typedef void(aws_signer_signing_complete_fn)(struct aws_signing_result *result, void *userdata);
+
 typedef int(aws_signer_sign_request_fn)(
     struct aws_signer *signer,
     const struct aws_signable *signable,
     const struct aws_signing_config_base *base_config,
-    struct aws_signing_result *result);
+    aws_signer_signing_complete_fn *on_complete,
+    void *userdata);
 typedef void(aws_signer_clean_up_fn)(struct aws_signer *signer);
 
 struct aws_signer_vtable {
@@ -63,7 +72,8 @@ int aws_signer_sign_request(
     struct aws_signer *signer,
     const struct aws_signable *signable,
     const struct aws_signing_config_base *base_config,
-    struct aws_signing_result *result);
+    aws_signer_signing_complete_fn *on_complete,
+    void *userdata);
 
 /*
  * Creates a new signer that performs AWS http request signing.  Requires an instance of

--- a/include/aws/auth/signing_config.h
+++ b/include/aws/auth/signing_config.h
@@ -23,7 +23,7 @@
 
 struct aws_credentials;
 
-typedef bool(aws_should_sign_param_fn)(const struct aws_byte_cursor *name);
+typedef bool(aws_should_sign_param_fn)(const struct aws_byte_cursor *name, void *userdata);
 
 /*
  * A primitive RTTI indicator for signing configuration structs
@@ -96,6 +96,7 @@ struct aws_signing_config_aws {
      * the internal check (skips x-amzn-trace-id, user-agent) and this function (if defined).
      */
     aws_should_sign_param_fn *should_sign_param;
+    void *should_sign_param_ud;
 
     /*
      * We assume the uri will be encoded once in preparation for transmission.  Certain services

--- a/include/aws/auth/signing_config.h
+++ b/include/aws/auth/signing_config.h
@@ -67,9 +67,9 @@ struct aws_signing_config_aws {
     enum aws_signing_algorithm algorithm;
 
     /*
-     * AWS credentials to sign with
+     * AWS credentials provider to fetch signing credentials with
      */
-    struct aws_credentials *credentials;
+    struct aws_credentials_provider *credentials_provider;
 
     /*
      * The region to sign against

--- a/source/aws_profile.c
+++ b/source/aws_profile.c
@@ -556,10 +556,8 @@ static int s_profile_merge(struct aws_profile *dest_profile, const struct aws_pr
                 return AWS_OP_ERR;
             }
 
-            struct aws_byte_cursor empty_value;
-            AWS_ZERO_STRUCT(empty_value);
-
             struct aws_byte_cursor property_name = aws_byte_cursor_from_string(dest_key);
+            static struct aws_byte_cursor empty_value = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("");
             dest_property = aws_profile_property_new(dest_profile->allocator, &property_name, &empty_value);
             if (dest_property == NULL) {
                 aws_string_destroy(dest_key);

--- a/source/aws_profile.c
+++ b/source/aws_profile.c
@@ -556,8 +556,10 @@ static int s_profile_merge(struct aws_profile *dest_profile, const struct aws_pr
                 return AWS_OP_ERR;
             }
 
+            struct aws_byte_cursor empty_value;
+            AWS_ZERO_STRUCT(empty_value);
+
             struct aws_byte_cursor property_name = aws_byte_cursor_from_string(dest_key);
-            static struct aws_byte_cursor empty_value = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("");
             dest_property = aws_profile_property_new(dest_profile->allocator, &property_name, &empty_value);
             if (dest_property == NULL) {
                 aws_string_destroy(dest_key);

--- a/source/aws_signing.c
+++ b/source/aws_signing.c
@@ -163,19 +163,28 @@ static int s_append_signing_algorithm(enum aws_signing_algorithm algorithm, stru
 /*
  * signing state management
  */
-int aws_signing_state_init(
-    struct aws_signing_state_aws *state,
+struct aws_signing_state_aws *aws_signing_state_new(
     struct aws_allocator *allocator,
     const struct aws_signing_config_aws *context,
     const struct aws_signable *signable,
-    struct aws_signing_result *result) {
+    aws_signer_signing_complete_fn *on_complete,
+    void *userdata) {
 
-    AWS_ZERO_STRUCT(*state);
+    struct aws_signing_state_aws *state = aws_mem_calloc(allocator, 1, sizeof(struct aws_signing_state_aws));
+    if (!state) {
+        return NULL;
+    }
 
     state->allocator = allocator;
     state->config = context;
     state->signable = signable;
-    state->result = result;
+    state->on_complete = on_complete;
+    state->userdata = userdata;
+
+    if (aws_signing_result_init(&state->result, allocator)) {
+
+        goto on_error;
+    }
 
     if (aws_byte_buf_init(&state->canonical_request, allocator, CANONICAL_REQUEST_STARTING_SIZE) ||
         aws_byte_buf_init(&state->string_to_sign, allocator, STRING_TO_SIGN_STARTING_SIZE) ||
@@ -189,15 +198,16 @@ int aws_signing_state_init(
         goto on_error;
     }
 
-    return AWS_OP_SUCCESS;
+    return state;
 
 on_error:
-    aws_signing_state_clean_up(state);
-
-    return AWS_OP_ERR;
+    aws_signing_state_destroy(state);
+    return NULL;
 }
 
-void aws_signing_state_clean_up(struct aws_signing_state_aws *state) {
+void aws_signing_state_destroy(struct aws_signing_state_aws *state) {
+    aws_signing_result_clean_up(&state->result);
+
     aws_byte_buf_clean_up(&state->canonical_request);
     aws_byte_buf_clean_up(&state->string_to_sign);
     aws_byte_buf_clean_up(&state->signed_headers);
@@ -206,6 +216,8 @@ void aws_signing_state_clean_up(struct aws_signing_state_aws *state) {
     aws_byte_buf_clean_up(&state->credential_scope);
     aws_byte_buf_clean_up(&state->access_credential_scope);
     aws_byte_buf_clean_up(&state->date);
+
+    aws_mem_release(state->allocator, state);
 }
 
 /*
@@ -515,7 +527,7 @@ static int s_add_authorization_query_param_with_encoding(
 
     struct aws_byte_cursor encoded_algorithm_value = aws_byte_cursor_from_buf(uri_encoded_buffer);
     if (aws_signing_result_append_property_list(
-            state->result, g_aws_http_query_params_property_list_name, &uri_param->key, &encoded_algorithm_value) ||
+            &state->result, g_aws_http_query_params_property_list_name, &uri_param->key, &encoded_algorithm_value) ||
         aws_array_list_push_back(query_params, uri_param)) {
         return AWS_OP_ERR;
     }
@@ -600,10 +612,9 @@ static int s_add_authorization_query_params(struct aws_signing_state_aws *state,
     /* X-Amz-Security-token */
     struct aws_byte_cursor security_token_name_cur = aws_byte_cursor_from_string(g_aws_signing_security_token_name);
 
-    if (state->config->credentials->session_token && s_should_sign_param(state, &security_token_name_cur)) {
+    if (state->credentials->session_token && s_should_sign_param(state, &security_token_name_cur)) {
         struct aws_uri_param security_token_param = {
-            .key = security_token_name_cur,
-            .value = aws_byte_cursor_from_string(state->config->credentials->session_token)};
+            .key = security_token_name_cur, .value = aws_byte_cursor_from_string(state->credentials->session_token)};
 
         if (s_add_authorization_query_param_with_encoding(
                 state, query_params, &security_token_param, &uri_encoded_value)) {
@@ -850,18 +861,21 @@ static int s_build_canonical_stable_header_list(
 
     struct aws_byte_cursor security_token_cur = aws_byte_cursor_from_string(g_aws_signing_security_token_name);
 
-    if (state->config->credentials->session_token && s_should_sign_param(state, &security_token_cur)) {
+    if (state->credentials->session_token && s_should_sign_param(state, &security_token_cur)) {
         /* X-Amz-Security-Token */
         struct stable_header session_token_header = {
             .original_index = additional_header_index++,
-            .header = {.name = security_token_cur,
-                       .value = aws_byte_cursor_from_string(state->config->credentials->session_token)}};
+            .header =
+                {
+                    .name = security_token_cur,
+                    .value = aws_byte_cursor_from_string(state->credentials->session_token),
+                },
+        };
         if (aws_array_list_push_back(stable_header_list, &session_token_header)) {
             return AWS_OP_ERR;
         }
 
-        *out_required_capacity +=
-            g_aws_signing_security_token_name->len + state->config->credentials->session_token->len;
+        *out_required_capacity += g_aws_signing_security_token_name->len + state->credentials->session_token->len;
     }
 
     if (!s_is_query_param_auth(state->config->algorithm)) {
@@ -928,7 +942,7 @@ static int s_build_canonical_headers(struct aws_signing_state_aws *state) {
         total_sign_headers_count += 1;
     }
 
-    if (state->config->credentials->session_token) {
+    if (state->credentials->session_token) {
         total_sign_headers_count += 1; /* for X-Amz-Security-Token */
     }
 
@@ -1100,7 +1114,10 @@ static int s_append_canonical_payload_hash(struct aws_signing_state_aws *state) 
     if (s_is_header_auth(state->config->algorithm)) {
         struct aws_byte_cursor hashed_body_header_name = aws_byte_cursor_from_string(g_aws_signing_content_header_name);
         if (aws_signing_result_append_property_list(
-                state->result, g_aws_http_headers_property_list_name, &hashed_body_header_name, &payload_hash_cursor)) {
+                &state->result,
+                g_aws_http_headers_property_list_name,
+                &hashed_body_header_name,
+                &payload_hash_cursor)) {
             return AWS_OP_ERR;
         }
     }
@@ -1174,7 +1191,7 @@ static int s_build_credential_scope(struct aws_signing_state_aws *state) {
     }
 
     /* While we're at it, build the accesskey/credential scope string which is used during query param signing*/
-    struct aws_byte_cursor access_key_cursor = aws_byte_cursor_from_string(state->config->credentials->access_key_id);
+    struct aws_byte_cursor access_key_cursor = aws_byte_cursor_from_string(state->credentials->access_key_id);
     if (aws_byte_buf_append_dynamic(&state->access_credential_scope, &access_key_cursor)) {
         return AWS_OP_ERR;
     }
@@ -1402,7 +1419,7 @@ static int s_compute_sigv4_signing_key(struct aws_signing_state_aws *state, stru
     AWS_ZERO_STRUCT(date_buf);
 
     if (aws_byte_buf_init(
-            &secret_key, allocator, s_secret_key_prefix->len + config->credentials->secret_access_key->len) ||
+            &secret_key, allocator, s_secret_key_prefix->len + state->credentials->secret_access_key->len) ||
         aws_byte_buf_init(&output, allocator, AWS_SHA256_LEN) ||
         aws_byte_buf_init(&date_buf, allocator, AWS_DATE_TIME_STR_MAX_LEN)) {
         goto cleanup;
@@ -1412,7 +1429,7 @@ static int s_compute_sigv4_signing_key(struct aws_signing_state_aws *state, stru
      * Prep Key
      */
     struct aws_byte_cursor prefix_cursor = aws_byte_cursor_from_string(s_secret_key_prefix);
-    struct aws_byte_cursor key_cursor = aws_byte_cursor_from_string(config->credentials->secret_access_key);
+    struct aws_byte_cursor key_cursor = aws_byte_cursor_from_string(state->credentials->secret_access_key);
     if (aws_byte_buf_append_dynamic(&secret_key, &prefix_cursor) ||
         aws_byte_buf_append_dynamic(&secret_key, &key_cursor)) {
         goto cleanup;
@@ -1531,13 +1548,13 @@ static int s_add_authorization_to_result(
     if (s_is_header_auth(state->config->algorithm)) {
         name = aws_byte_cursor_from_string(g_aws_signing_authorization_header_name);
         return aws_signing_result_append_property_list(
-            state->result, g_aws_http_headers_property_list_name, &name, &value);
+            &state->result, g_aws_http_headers_property_list_name, &name, &value);
     }
 
     if (s_is_query_param_auth(state->config->algorithm)) {
         name = aws_byte_cursor_from_string(g_aws_signing_authorization_query_param_name);
         return aws_signing_result_append_property_list(
-            state->result, g_aws_http_query_params_property_list_name, &name, &value);
+            &state->result, g_aws_http_query_params_property_list_name, &name, &value);
     }
 
     return AWS_OP_ERR;
@@ -1566,7 +1583,7 @@ static int s_append_authorization_header_preamble(struct aws_signing_state_aws *
         return AWS_OP_ERR;
     }
 
-    struct aws_byte_cursor access_key_cursor = aws_byte_cursor_from_string(state->config->credentials->access_key_id);
+    struct aws_byte_cursor access_key_cursor = aws_byte_cursor_from_string(state->credentials->access_key_id);
     if (aws_byte_buf_append_dynamic(dest, &access_key_cursor)) {
         return AWS_OP_ERR;
     }
@@ -1635,16 +1652,16 @@ int aws_signing_build_authorization_value(struct aws_signing_state_aws *state) {
     struct aws_byte_cursor date_header_name = aws_byte_cursor_from_string(g_aws_signing_date_name);
     struct aws_byte_cursor date_header_value = aws_byte_cursor_from_buf(&state->date);
     if (aws_signing_result_append_property_list(
-            state->result, g_aws_http_headers_property_list_name, &date_header_name, &date_header_value)) {
+            &state->result, g_aws_http_headers_property_list_name, &date_header_name, &date_header_value)) {
         return AWS_OP_ERR;
     }
 
     /*
      * Add Security token to the signing result if a session token was present.
      */
-    if (state->config->credentials->session_token) {
+    if (state->credentials->session_token) {
         struct aws_byte_cursor session_token_name = aws_byte_cursor_from_string(g_aws_signing_security_token_name);
-        struct aws_byte_cursor session_token = aws_byte_cursor_from_string(state->config->credentials->session_token);
+        struct aws_byte_cursor session_token = aws_byte_cursor_from_string(state->credentials->session_token);
 
         const struct aws_string *property_list_name = g_aws_http_headers_property_list_name;
 
@@ -1666,7 +1683,7 @@ int aws_signing_build_authorization_value(struct aws_signing_state_aws *state) {
         }
 
         if (aws_signing_result_append_property_list(
-                state->result, property_list_name, &session_token_name, &session_token)) {
+                &state->result, property_list_name, &session_token_name, &session_token)) {
             goto cleanup;
         }
     }

--- a/source/aws_signing.c
+++ b/source/aws_signing.c
@@ -541,7 +541,7 @@ static int s_add_authorization_query_param_with_encoding(
  */
 static bool s_should_sign_param(struct aws_signing_state_aws *state, struct aws_byte_cursor *name) {
     if (state->config->should_sign_param) {
-        if (!state->config->should_sign_param(name)) {
+        if (!state->config->should_sign_param(name, state->config->should_sign_param_ud)) {
             return false;
         }
     }

--- a/source/credentials_provider_static.c
+++ b/source/credentials_provider_static.c
@@ -63,8 +63,8 @@ struct aws_credentials_provider *aws_credentials_provider_new_static(
 
     AWS_ZERO_STRUCT(*provider);
 
-    struct aws_credentials *credentials =
-        aws_credentials_new_from_cursors(allocator, &access_key_id, &secret_access_key, &session_token);
+    struct aws_credentials *credentials = aws_credentials_new_from_cursors(
+        allocator, &access_key_id, &secret_access_key, session_token.len ? &session_token : NULL);
     if (credentials == NULL) {
         goto on_new_credentials_failure;
     }

--- a/source/signer.c
+++ b/source/signer.c
@@ -15,6 +15,7 @@
 
 #include <aws/auth/signer.h>
 
+#include <aws/auth/credentials.h>
 #include <aws/auth/private/aws_signing.h>
 #include <aws/io/uri.h>
 
@@ -33,93 +34,114 @@ int aws_signer_sign_request(
     struct aws_signer *signer,
     const struct aws_signable *signable,
     const struct aws_signing_config_base *base_config,
-    struct aws_signing_result *result) {
+    aws_signer_signing_complete_fn *on_complete,
+    void *userdata) {
+
     AWS_ASSERT(signer && signable);
     AWS_ASSERT(signer->vtable && signer->vtable->sign_request);
 
-    return signer->vtable->sign_request(signer, signable, base_config, result);
+    return signer->vtable->sign_request(signer, signable, base_config, on_complete, userdata);
 }
 
 /*
  * Aws signing implementation
  */
 
+aws_on_get_credentials_callback_fn s_aws_signer_on_get_credentials;
+
 static int s_aws_signer_aws_sign_request(
     struct aws_signer *signer,
     const struct aws_signable *signable,
     const struct aws_signing_config_base *base_config,
-    struct aws_signing_result *result) {
+    aws_signer_signing_complete_fn *on_complete,
+    void *userdata) {
+
     if (base_config->config_type != AWS_SIGNING_CONFIG_AWS) {
         return aws_raise_error(AWS_AUTH_SIGNING_MISMATCHED_CONFIGURATION);
     }
 
-    int signing_result = AWS_OP_ERR;
-
     const struct aws_signing_config_aws *config = (void *)base_config;
 
-    struct aws_signing_state_aws signing_state;
-    AWS_ZERO_STRUCT(signing_state);
+    struct aws_signing_state_aws *signing_state =
+        aws_signing_state_new(signer->allocator, config, signable, on_complete, userdata);
+    if (!signing_state) {
+        return AWS_OP_ERR;
+    }
 
-    if (aws_signing_state_init(&signing_state, signer->allocator, config, signable, result)) {
+    if (aws_credentials_provider_get_credentials(
+            config->credentials_provider, s_aws_signer_on_get_credentials, signing_state)) {
         goto cleanup;
     }
 
-    if (aws_signing_build_canonical_request(&signing_state)) {
+    return AWS_OP_SUCCESS;
+
+cleanup:
+    aws_signing_state_destroy(signing_state);
+    return AWS_OP_ERR;
+}
+
+void s_aws_signer_on_get_credentials(struct aws_credentials *credentials, void *user_data) {
+    struct aws_signing_state_aws *state = user_data;
+    state->credentials = credentials;
+
+    struct aws_signing_result *result = NULL;
+
+    if (aws_signing_build_canonical_request(state)) {
         AWS_LOGF_ERROR(
             AWS_LS_AUTH_SIGNING,
             "(id=%p) Http request failed to build canonical request via algorithm %s",
-            (void *)signable,
-            aws_signing_algorithm_to_string(config->algorithm));
+            (void *)state->signable,
+            aws_signing_algorithm_to_string(state->config->algorithm));
         goto cleanup;
     }
 
     AWS_LOGF_INFO(
         AWS_LS_AUTH_SIGNING,
         "(id=%p) Http request successfully built canonical request for algorithm %s, with contents \"" PRInSTR "\"",
-        (void *)signable,
-        aws_signing_algorithm_to_string(config->algorithm),
-        AWS_BYTE_BUF_PRI(signing_state.canonical_request));
+        (void *)state->signable,
+        aws_signing_algorithm_to_string(state->config->algorithm),
+        AWS_BYTE_BUF_PRI(state->canonical_request));
 
-    if (aws_signing_build_string_to_sign(&signing_state)) {
+    if (aws_signing_build_string_to_sign(state)) {
         AWS_LOGF_ERROR(
             AWS_LS_AUTH_SIGNING,
             "(id=%p) Http request failed to build string-to-sign via algorithm %s",
-            (void *)signable,
-            aws_signing_algorithm_to_string(config->algorithm));
+            (void *)state->signable,
+            aws_signing_algorithm_to_string(state->config->algorithm));
         goto cleanup;
     }
 
     AWS_LOGF_INFO(
         AWS_LS_AUTH_SIGNING,
         "(id=%p) Http request successfully built string-to-sign via algorithm %s, with contents \"" PRInSTR "\"",
-        (void *)signable,
-        aws_signing_algorithm_to_string(config->algorithm),
-        AWS_BYTE_BUF_PRI(signing_state.string_to_sign));
+        (void *)state->signable,
+        aws_signing_algorithm_to_string(state->config->algorithm),
+        AWS_BYTE_BUF_PRI(state->string_to_sign));
 
-    if (aws_signing_build_authorization_value(&signing_state)) {
+    if (aws_signing_build_authorization_value(state)) {
         AWS_LOGF_ERROR(
             AWS_LS_AUTH_SIGNING,
             "(id=%p) Http request failed to build final authorization value via algorithm %s",
-            (void *)signable,
-            aws_signing_algorithm_to_string(config->algorithm));
+            (void *)state->signable,
+            aws_signing_algorithm_to_string(state->config->algorithm));
         goto cleanup;
     }
 
-    signing_result = AWS_OP_SUCCESS;
+    result = &state->result;
 
 cleanup:
-
-    aws_signing_state_clean_up(&signing_state);
-
-    return signing_result;
+    state->on_complete(result, state->userdata);
+    aws_signing_state_destroy(state);
 }
 
 static void s_aws_signer_aws_clean_up(struct aws_signer *signer) {
     (void)signer;
 }
 
-static struct aws_signer_vtable s_aws_signer_aws_vtable = {.sign_request = s_aws_signer_aws_sign_request,
-                                                           .clean_up = s_aws_signer_aws_clean_up};
+static struct aws_signer_vtable s_aws_signer_aws_vtable = {
+    .sign_request = s_aws_signer_aws_sign_request,
+    .clean_up = s_aws_signer_aws_clean_up,
+};
 
 struct aws_signer *aws_signer_new_aws(struct aws_allocator *allocator) {
     struct aws_signer *signer = aws_mem_acquire(allocator, sizeof(struct aws_signer));

--- a/source/sigv4_http_request.c
+++ b/source/sigv4_http_request.c
@@ -308,47 +308,58 @@ on_error:
 /*
  * Utility struct/API to let us wait on credentials resolution
  */
-struct aws_credentials_waiter {
+struct aws_signing_waiter {
     struct aws_mutex lock;
     struct aws_condition_variable signal;
-    struct aws_credentials *credentials;
     bool done;
+
+    struct aws_allocator *allocator;
+    struct aws_http_message *request;
 };
 
-static int s_aws_credentials_waiter_init(struct aws_credentials_waiter *waiter) {
+static int s_aws_signing_waiter_init(
+    struct aws_signing_waiter *waiter,
+    struct aws_allocator *allocator,
+    struct aws_http_message *request) {
+
+    waiter->allocator = allocator;
+    waiter->request = request;
+
     if (aws_mutex_init(&waiter->lock)) {
         return AWS_OP_ERR;
     }
 
     if (aws_condition_variable_init(&waiter->signal)) {
+        aws_mutex_clean_up(&waiter->lock);
         return AWS_OP_ERR;
     }
 
     return AWS_OP_SUCCESS;
 }
 
-static void s_aws_credentials_waiter_clean_up(struct aws_credentials_waiter *waiter) {
+static void s_aws_signing_waiter_clean_up(struct aws_signing_waiter *waiter) {
     aws_mutex_clean_up(&waiter->lock);
     aws_condition_variable_clean_up(&waiter->signal);
-    aws_credentials_destroy(waiter->credentials);
 }
 
-void s_get_credentials_callback(struct aws_credentials *credentials, void *user_data) {
-    struct aws_credentials_waiter *waiter = user_data;
+void s_sign_callback(struct aws_signing_result *result, void *user_data) {
+    struct aws_signing_waiter *waiter = user_data;
     aws_mutex_lock(&waiter->lock);
+
+    aws_apply_signing_result_to_http_request(waiter->request, waiter->allocator, result);
+
     waiter->done = true;
-    waiter->credentials = aws_credentials_new_copy(credentials->allocator, credentials);
     aws_condition_variable_notify_one(&waiter->signal);
     aws_mutex_unlock(&waiter->lock);
 }
 
 bool s_wait_predicate(void *user_data) {
-    struct aws_credentials_waiter *waiter = user_data;
+    struct aws_signing_waiter *waiter = user_data;
 
     return waiter->done;
 }
 
-void s_aws_credentials_waiter_wait_on_credentials(struct aws_credentials_waiter *waiter) {
+void s_aws_signing_waiter_wait_on_credentials(struct aws_signing_waiter *waiter) {
     aws_mutex_lock(&waiter->lock);
     if (!waiter->done) {
         aws_condition_variable_wait_pred(&waiter->signal, &waiter->lock, s_wait_predicate, waiter);
@@ -369,8 +380,8 @@ int aws_sign_http_request_sigv4(struct aws_http_message *request, struct aws_all
     struct aws_signing_config_aws config;
     AWS_ZERO_STRUCT(config);
 
-    struct aws_credentials_waiter credentials_waiter;
-    AWS_ZERO_STRUCT(credentials_waiter);
+    struct aws_signing_waiter signing_waiter;
+    AWS_ZERO_STRUCT(signing_waiter);
 
     struct aws_credentials_provider_profile_options provider_options;
     AWS_ZERO_STRUCT(provider_options);
@@ -406,12 +417,9 @@ int aws_sign_http_request_sigv4(struct aws_http_message *request, struct aws_all
     /*
      * Initialize credentials waiter and wait for credentials resolution
      */
-    if (s_aws_credentials_waiter_init(&credentials_waiter)) {
+    if (s_aws_signing_waiter_init(&signing_waiter, allocator, request)) {
         goto done;
     }
-
-    aws_credentials_provider_get_credentials(provider, s_get_credentials_callback, &credentials_waiter);
-    s_aws_credentials_waiter_wait_on_credentials(&credentials_waiter);
 
     /*
      * Pull out required context key-value pairs: region and service
@@ -432,7 +440,7 @@ int aws_sign_http_request_sigv4(struct aws_http_message *request, struct aws_all
     /*
      * configure the signing request
      */
-    config.credentials = credentials_waiter.credentials;
+    config.credentials_provider = provider;
     config.config_type = AWS_SIGNING_CONFIG_AWS;
     config.algorithm = AWS_SIGNING_ALGORITHM_SIG_V4_HEADER;
     config.region = aws_byte_cursor_from_string(region);
@@ -446,17 +454,18 @@ int aws_sign_http_request_sigv4(struct aws_http_message *request, struct aws_all
     /*
      * Perform the signing process and apply the result to the request
      */
-    if (aws_signer_sign_request(signer, signable, (void *)&config, &signing_result)) {
+    if (aws_signer_sign_request(
+            signer, signable, (struct aws_signing_config_base *)&config, s_sign_callback, &config)) {
         goto done;
     }
 
-    aws_apply_signing_result_to_http_request(request, allocator, &signing_result);
+    s_aws_signing_waiter_wait_on_credentials(&signing_waiter);
 
     result = AWS_OP_SUCCESS;
 
 done:
 
-    s_aws_credentials_waiter_clean_up(&credentials_waiter);
+    s_aws_signing_waiter_clean_up(&signing_waiter);
     aws_credentials_provider_release(provider);
     aws_signer_destroy(signer);
     aws_signable_destroy(signable);

--- a/tests/sigv4_tests.c
+++ b/tests/sigv4_tests.c
@@ -774,7 +774,9 @@ AWS_STATIC_STRING_FROM_LITERAL(
     "host;x-amz-date\n"
     "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855");
 
-static bool s_should_sign_header(const struct aws_byte_cursor *name) {
+static bool s_should_sign_header(const struct aws_byte_cursor *name, void *userdata) {
+    (void)userdata;
+
     struct aws_byte_cursor my_header_cursor = aws_byte_cursor_from_c_str("myheader");
     struct aws_byte_cursor another_header_cursor = aws_byte_cursor_from_c_str("anOtherHeader");
 


### PR DESCRIPTION
* `aws_signer_sign_request` is now async
* `aws_signing_config_aws` now uses a credentials provider instead of a raw credentials object

Also fixes small Mike-isms:
* Allow static credentials provider to accept an empty session token
* Add userdata to aws_should_sign_param_fn`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
