### PR TITLE
Changing byte buffer append operation to be dynamic.

### DIFF
--- a/source/aws_signing.c
+++ b/source/aws_signing.c
@@ -1426,7 +1426,7 @@ static int s_build_canonical_request_sigv4(struct aws_signing_state_aws *state) 
     }
 
     struct aws_byte_cursor header_block_cursor = aws_byte_cursor_from_buf(&state->canonical_header_block);
-    if (aws_byte_buf_append(&state->canonical_request, &header_block_cursor)) {
+    if (aws_byte_buf_append_dynamic(&state->canonical_request, &header_block_cursor)) {
         goto cleanup;
     }
 


### PR DESCRIPTION
*Description of changes:*

state->canonical_request is a growable buffer, and the append operation currently used in s_build_canonical_request_sigv4 does not allow growth, which can cause errors.  Replacing 'aws_byte_buf_append' with 'aws_byte_buf_append_dynamic' to fix this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
