### PR TITLE
Properly use and separate high res and system time

### DIFF
--- a/include/aws/auth/credentials.h
+++ b/include/aws/auth/credentials.h
@@ -140,6 +140,8 @@ struct aws_credentials_provider_cached_options {
     struct aws_credentials_provider_shutdown_options shutdown_options;
     struct aws_credentials_provider *source;
     uint64_t refresh_time_in_milliseconds;
+
+    /* For mocking, leave NULL otherwise */
     aws_io_clock_fn *high_res_clock_fn;
     aws_io_clock_fn *system_clock_fn;
 };

--- a/include/aws/auth/credentials.h
+++ b/include/aws/auth/credentials.h
@@ -140,7 +140,8 @@ struct aws_credentials_provider_cached_options {
     struct aws_credentials_provider_shutdown_options shutdown_options;
     struct aws_credentials_provider *source;
     uint64_t refresh_time_in_milliseconds;
-    aws_io_clock_fn *clock_fn;
+    aws_io_clock_fn *high_res_clock_fn;
+    aws_io_clock_fn *system_clock_fn;
 };
 
 struct aws_credentials_provider_chain_options {
@@ -168,7 +169,7 @@ struct aws_credentials_provider_sts_options {
 
     /* For mocking, leave NULL otherwise */
     struct aws_credentials_provider_system_vtable *function_table;
-    aws_io_clock_fn *clock_fn;
+    aws_io_clock_fn *system_clock_fn;
 };
 
 struct aws_credentials_provider_chain_default_options {

--- a/source/credentials_provider_sts.c
+++ b/source/credentials_provider_sts.c
@@ -88,7 +88,7 @@ struct aws_credentials_provider_sts_impl {
     struct aws_credentials_provider_shutdown_options source_shutdown_options;
     struct aws_credentials_provider_system_vtable *function_table;
     bool owns_ctx;
-    aws_io_clock_fn *clock_fn;
+    aws_io_clock_fn *system_clock_fn;
 };
 
 struct sts_creds_provider_user_data {
@@ -264,7 +264,7 @@ static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_co
             aws_mem_calloc(provider_user_data->allocator, 1, sizeof(struct aws_credentials));
 
         uint64_t now = UINT64_MAX;
-        if (provider_impl->clock_fn(&now) != AWS_OP_SUCCESS) {
+        if (provider_impl->system_clock_fn(&now) != AWS_OP_SUCCESS) {
             goto finish;
         }
 
@@ -635,10 +635,10 @@ struct aws_credentials_provider *aws_credentials_provider_new_sts(
 
     impl->duration_seconds = options->duration_seconds;
 
-    if (options->clock_fn != NULL) {
-        impl->clock_fn = options->clock_fn;
+    if (options->system_clock_fn != NULL) {
+        impl->system_clock_fn = options->system_clock_fn;
     } else {
-        impl->clock_fn = aws_sys_clock_get_ticks;
+        impl->system_clock_fn = aws_sys_clock_get_ticks;
     }
 
     /* minimum for STS is 900 seconds*/

--- a/tests/credentials_provider_utils.c
+++ b/tests/credentials_provider_utils.c
@@ -386,28 +386,53 @@ on_query_list_init_failure:
 }
 
 /*
- * mock clock
+ * mock system clock
  */
 
-static struct aws_mutex clock_sync = AWS_MUTEX_INIT;
-static uint64_t clock_time = 0;
+static struct aws_mutex system_clock_sync = AWS_MUTEX_INIT;
+static uint64_t system_clock_time = 0;
 
-int mock_aws_get_time(uint64_t *current_time) {
-    aws_mutex_lock(&clock_sync);
+int mock_aws_get_system_time(uint64_t *current_time) {
+    aws_mutex_lock(&system_clock_sync);
 
-    *current_time = clock_time;
+    *current_time = system_clock_time;
 
-    aws_mutex_unlock(&clock_sync);
+    aws_mutex_unlock(&system_clock_sync);
 
     return AWS_OP_SUCCESS;
 }
 
-void mock_aws_set_time(uint64_t current_time) {
-    aws_mutex_lock(&clock_sync);
+void mock_aws_set_system_time(uint64_t current_time) {
+    aws_mutex_lock(&system_clock_sync);
 
-    clock_time = current_time;
+    system_clock_time = current_time;
 
-    aws_mutex_unlock(&clock_sync);
+    aws_mutex_unlock(&system_clock_sync);
+}
+
+/*
+ * mock high res clock
+ */
+
+static struct aws_mutex high_res_clock_sync = AWS_MUTEX_INIT;
+static uint64_t high_res_clock_time = 0;
+
+int mock_aws_get_high_res_time(uint64_t *current_time) {
+    aws_mutex_lock(&high_res_clock_sync);
+
+    *current_time = high_res_clock_time;
+
+    aws_mutex_unlock(&high_res_clock_sync);
+
+    return AWS_OP_SUCCESS;
+}
+
+void mock_aws_set_high_res_time(uint64_t current_time) {
+    aws_mutex_lock(&high_res_clock_sync);
+
+    high_res_clock_time = current_time;
+
+    aws_mutex_unlock(&high_res_clock_sync);
 }
 
 /*

--- a/tests/credentials_provider_utils.h
+++ b/tests/credentials_provider_utils.h
@@ -96,10 +96,13 @@ struct aws_credentials_provider *aws_credentials_provider_new_mock_async(
     struct aws_credentials_provider_shutdown_options *shutdown_options);
 
 /*
- * Simple global clock mock
+ * Simple global clock mocks
  */
-int mock_aws_get_time(uint64_t *current_time);
-void mock_aws_set_time(uint64_t current_time);
+int mock_aws_get_system_time(uint64_t *current_time);
+void mock_aws_set_system_time(uint64_t current_time);
+
+int mock_aws_get_high_res_time(uint64_t *current_time);
+void mock_aws_set_high_res_time(uint64_t current_time);
 
 /*
  * Credentials provider that always returns NULL.  Useful for chain tests.

--- a/tests/credentials_tests.c
+++ b/tests/credentials_tests.c
@@ -381,7 +381,8 @@ static int s_verify_callback_status(
 static int s_cached_credentials_provider_elapsed_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    mock_aws_set_time(1);
+    mock_aws_set_system_time(0);
+    mock_aws_set_high_res_time(1);
 
     s_aws_credentials_shutdown_checker_init();
 
@@ -405,7 +406,8 @@ static int s_cached_credentials_provider_elapsed_test(struct aws_allocator *allo
     AWS_ZERO_STRUCT(options);
     options.source = mock_provider;
     options.refresh_time_in_milliseconds = TEST_CACHE_REFRESH_TIME_MS;
-    options.clock_fn = mock_aws_get_time;
+    options.high_res_clock_fn = mock_aws_get_high_res_time;
+    options.system_clock_fn = mock_aws_get_system_time;
     options.shutdown_options.shutdown_callback = s_on_shutdown_complete;
     options.shutdown_options.shutdown_user_data = NULL;
 
@@ -442,8 +444,8 @@ static int s_cached_credentials_provider_elapsed_test(struct aws_allocator *allo
     uint64_t refresh_in_ns =
         aws_timestamp_convert(TEST_CACHE_REFRESH_TIME_MS, AWS_TIMESTAMP_MILLIS, AWS_TIMESTAMP_NANOS, NULL);
     uint64_t now = 0;
-    mock_aws_get_time(&now);
-    mock_aws_set_time(now + refresh_in_ns - 1);
+    mock_aws_get_high_res_time(&now);
+    mock_aws_set_high_res_time(now + refresh_in_ns - 1);
 
     aws_get_credentials_test_callback_result_clean_up(&callback_results);
     ASSERT_TRUE(s_invoke_get_credentials(cached_provider, &callback_results, 1) == 0);
@@ -455,7 +457,7 @@ static int s_cached_credentials_provider_elapsed_test(struct aws_allocator *allo
     /*
      * Advance time enough to cause cache expiration, verify we get the second set of mocked credentials
      */
-    mock_aws_set_time(now + refresh_in_ns);
+    mock_aws_set_high_res_time(now + refresh_in_ns);
 
     aws_get_credentials_test_callback_result_clean_up(&callback_results);
     ASSERT_TRUE(s_invoke_get_credentials(cached_provider, &callback_results, 1) == 0);
@@ -484,7 +486,8 @@ static int s_cached_credentials_provider_queued_async_test(struct aws_allocator 
 
     s_aws_credentials_shutdown_checker_init();
 
-    mock_aws_set_time(1);
+    mock_aws_set_system_time(0);
+    mock_aws_set_high_res_time(1);
 
     struct aws_credentials *first_creds =
         aws_credentials_new(allocator, s_access_key_id_1, s_secret_access_key_1, s_session_token_1);
@@ -507,7 +510,8 @@ static int s_cached_credentials_provider_queued_async_test(struct aws_allocator 
     AWS_ZERO_STRUCT(options);
     options.source = mock_provider;
     options.refresh_time_in_milliseconds = TEST_CACHE_REFRESH_TIME_MS;
-    options.clock_fn = mock_aws_get_time;
+    options.high_res_clock_fn = mock_aws_get_high_res_time;
+    options.system_clock_fn = mock_aws_get_system_time;
     options.shutdown_options.shutdown_callback = s_on_shutdown_complete;
     options.shutdown_options.shutdown_user_data = NULL;
 
@@ -545,8 +549,8 @@ static int s_cached_credentials_provider_queued_async_test(struct aws_allocator 
     uint64_t refresh_in_ns =
         aws_timestamp_convert(TEST_CACHE_REFRESH_TIME_MS, AWS_TIMESTAMP_MILLIS, AWS_TIMESTAMP_NANOS, NULL);
     uint64_t now = 0;
-    mock_aws_get_time(&now);
-    mock_aws_set_time(now + refresh_in_ns - 1);
+    mock_aws_get_high_res_time(&now);
+    mock_aws_set_high_res_time(now + refresh_in_ns - 1);
 
     aws_get_credentials_test_callback_result_clean_up(&callback_results);
     ASSERT_TRUE(s_invoke_get_credentials(cached_provider, &callback_results, 2) == 0);
@@ -558,7 +562,7 @@ static int s_cached_credentials_provider_queued_async_test(struct aws_allocator 
     /*
      * Advance time enough to cause cache expiration, verify we get the second set of mocked credentials
      */
-    mock_aws_set_time(now + refresh_in_ns);
+    mock_aws_set_high_res_time(now + refresh_in_ns);
 
     aws_get_credentials_test_callback_result_clean_up(&callback_results);
     ASSERT_TRUE(s_invoke_get_credentials(cached_provider, &callback_results, 2) == 0);


### PR DESCRIPTION
* Correct math that involved system clock calculations being applied to high res timepoints.
* Added additional mocking so that cached credentials provider could be properly tested.
* Update tests appropriately.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
