### PR TITLE
Fix Memory Leak in Test

### DIFF
--- a/include/aws/auth/private/credentials_utils.h
+++ b/include/aws/auth/private/credentials_utils.h
@@ -84,7 +84,6 @@ AWS_EXTERN_C_BEGIN
 AWS_AUTH_API
 void aws_credentials_query_init(
     struct aws_credentials_query *query,
-    struct aws_credentials_provider *provider,
     aws_on_get_credentials_callback_fn *callback,
     void *user_data);
 

--- a/source/credentials_provider_cached.c
+++ b/source/credentials_provider_cached.c
@@ -166,7 +166,7 @@ static int s_cached_credentials_provider_get_credentials_async(
         struct aws_credentials_query *query =
             aws_mem_acquire(provider->allocator, sizeof(struct aws_credentials_query));
         if (query != NULL) {
-            aws_credentials_query_init(query, provider, callback, user_data);
+            aws_credentials_query_init(query, callback, user_data);
             should_submit_query = aws_linked_list_empty(&impl->pending_queries);
             aws_linked_list_push_back(&impl->pending_queries, &query->node);
         } else {

--- a/source/credentials_utils.c
+++ b/source/credentials_utils.c
@@ -17,22 +17,15 @@
 
 void aws_credentials_query_init(
     struct aws_credentials_query *query,
-    struct aws_credentials_provider *provider,
     aws_on_get_credentials_callback_fn *callback,
     void *user_data) {
     AWS_ZERO_STRUCT(*query);
-
-    query->provider = provider;
     query->user_data = user_data;
     query->callback = callback;
-
-    aws_credentials_provider_acquire(provider);
 }
 
 void aws_credentials_query_clean_up(struct aws_credentials_query *query) {
-    if (query != NULL) {
-        aws_credentials_provider_release(query->provider);
-    }
+    (void)query;
 }
 
 void aws_credentials_provider_init_base(

--- a/tests/credentials_provider_utils.c
+++ b/tests/credentials_provider_utils.c
@@ -216,7 +216,7 @@ static int s_async_mock_credentials_provider_get_credentials_async(
     struct aws_credentials_query query;
     AWS_ZERO_STRUCT(query);
 
-    aws_credentials_query_init(&query, provider, callback, user_data);
+    aws_credentials_query_init(&query, callback, user_data);
 
     aws_array_list_push_back(&impl->queries, &query);
 
@@ -229,8 +229,6 @@ static void s_async_mock_credentials_provider_destroy(struct aws_credentials_pro
     struct aws_credentials_provider_mock_async_impl *impl =
         (struct aws_credentials_provider_mock_async_impl *)provider->impl;
 
-    aws_credentials_provider_invoke_shutdown_callback(provider);
-
     aws_mutex_lock(&impl->controller->sync);
     impl->controller->should_quit = true;
     aws_condition_variable_notify_one(&impl->controller->signal);
@@ -241,6 +239,8 @@ static void s_async_mock_credentials_provider_destroy(struct aws_credentials_pro
 
     aws_array_list_clean_up(&impl->queries);
     aws_array_list_clean_up(&impl->mock_results);
+
+    aws_credentials_provider_invoke_shutdown_callback(provider);
 
     aws_mem_release(provider->allocator, provider);
 }


### PR DESCRIPTION
*Issue #, if available:*
Following scripts will cache a memory leak caused by test `cached_credentials_provider_queued_async_test`
```
#!/bin/sh
while [ $? == 0 ]
do
    ./aws-c-auth-tests cached_credentials_provider_queued_async_test
done
```
The leak happens because:
- Mocked credentials provider will create a worker thread to process the queries.
- aws_credentials_query will ref cnt incr credentials provider, here is mocked credentials provider.
- Cached credentials provider's source is mocked provider.
- When test finished, cached provider got released in main thread and will wait its shutdown callback to be finished in `s_aws_wait_for_provider_shutdown_callback();` at main thread.
https://github.com/awslabs/aws-c-auth/blob/543e3764d7fa4f1228ed630d1aa40e4a0de396d6/tests/credentials_tests.c#L574-L576
- Well cached provider's shutdown callback is invoked when mock provider get destroyed. **here is the trick and important part**. 
  - Mocked provider's shutdown callback is invoked in its destroy function. https://github.com/awslabs/aws-c-auth/blob/543e3764d7fa4f1228ed630d1aa40e4a0de396d6/tests/credentials_provider_utils.c#L232
  - This call back is https://github.com/awslabs/aws-c-auth/blob/543e3764d7fa4f1228ed630d1aa40e4a0de396d6/source/credentials_provider_cached.c#L323
  - Which is cached providers' concrete destroy function, in this function, it will invoke it's own shutdown callback, which is https://github.com/awslabs/aws-c-auth/blob/543e3764d7fa4f1228ed630d1aa40e4a0de396d6/tests/credentials_tests.c#L515
  - This callback happens before joining worker thread and will wake up main thread from `s_aws_wait_for_provider_shutdown_callback();`
- In this case, main thread continues and goto mem check in test finish, but if worker thread is still processing queries and not yet destroyed mock provider (because query will hold mock provider), mem check will report leak.

Apart from this leak, there is dead lock race condition in mock provider's destroy function.
- Worker thread will first acquire controller's mutex before doing its job. https://github.com/awslabs/aws-c-auth/blob/543e3764d7fa4f1228ed630d1aa40e4a0de396d6/tests/credentials_provider_utils.c#L264
- When doing its job, it may call query_clean_up, which will de ref cnt mock provider, and potentially call mock provider's destroy function if ref cnt becomes zero.https://github.com/awslabs/aws-c-auth/blob/543e3764d7fa4f1228ed630d1aa40e4a0de396d6/tests/credentials_provider_utils.c#L298
- Well in destroy function, it tries to acquire lock again. https://github.com/awslabs/aws-c-auth/blob/543e3764d7fa4f1228ed630d1aa40e4a0de396d6/tests/credentials_provider_utils.c#L234


*Description of changes:*
First things first, debugging cached creds provider with async mock is a nightmare. 

- Changed mock provider's callback to happen after thread join, so that making sure main thread will wait worker thread to finish first.
- Removed provider reference in query so that clean up query won't cause dead lock. This is still in question though because currently provider in query is not used anywhere, but I don't know the purpose why we have it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
