### PR TITLE
Fix deadlock and leak with mock async provider

### DIFF
--- a/tests/credentials_provider_utils.c
+++ b/tests/credentials_provider_utils.c
@@ -229,8 +229,6 @@ static void s_async_mock_credentials_provider_destroy(struct aws_credentials_pro
     struct aws_credentials_provider_mock_async_impl *impl =
         (struct aws_credentials_provider_mock_async_impl *)provider->impl;
 
-    aws_credentials_provider_invoke_shutdown_callback(provider);
-
     aws_mutex_lock(&impl->controller->sync);
     impl->controller->should_quit = true;
     aws_condition_variable_notify_one(&impl->controller->signal);
@@ -241,6 +239,8 @@ static void s_async_mock_credentials_provider_destroy(struct aws_credentials_pro
 
     aws_array_list_clean_up(&impl->queries);
     aws_array_list_clean_up(&impl->mock_results);
+
+    aws_credentials_provider_invoke_shutdown_callback(provider);
 
     aws_mem_release(provider->allocator, provider);
 }
@@ -262,6 +262,12 @@ static void mock_async_background_thread_function(void *arg) {
 
     bool done = false;
     aws_mutex_lock(&impl->controller->sync);
+
+    struct aws_array_list temp_queries;
+    AWS_FATAL_ASSERT(
+        aws_array_list_init_dynamic(&temp_queries, impl->queries.alloc, 10, sizeof(struct aws_credentials_query)) ==
+        AWS_OP_SUCCESS);
+
     while (!done) {
 
         aws_condition_variable_wait_pred(
@@ -285,10 +291,15 @@ static void mock_async_background_thread_function(void *arg) {
                 AWS_FATAL_ASSERT(false);
             }
 
+            aws_array_list_swap_contents(&temp_queries, &impl->queries);
+            aws_array_list_clear(&impl->queries);
+
+            aws_mutex_unlock(&impl->controller->sync);
+
             for (size_t i = 0; i < callback_count; ++i) {
                 struct aws_credentials_query query;
                 AWS_ZERO_STRUCT(query);
-                if (aws_array_list_get_at(&impl->queries, &query, i)) {
+                if (aws_array_list_get_at(&temp_queries, &query, i)) {
                     continue;
                 }
 
@@ -298,13 +309,16 @@ static void mock_async_background_thread_function(void *arg) {
                 aws_credentials_query_clean_up(&query);
             }
 
+            aws_mutex_lock(&impl->controller->sync);
+
             impl->next_result++;
 
-            aws_array_list_clear(&impl->queries);
+            aws_array_list_clear(&temp_queries);
         }
     }
 
     aws_array_list_clear(&impl->queries);
+    aws_array_list_clean_up(&temp_queries);
 
     aws_mutex_unlock(&impl->controller->sync);
 }


### PR DESCRIPTION
This merges Andrew's fix for the leak and a deadlock workaround by making sure the lock isn't held while invoking callbacks.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
