### PR TITLE
Add proxy support to x509 provider

### DIFF
--- a/include/aws/auth/credentials.h
+++ b/include/aws/auth/credentials.h
@@ -211,16 +211,24 @@ struct aws_credentials_provider_x509_options {
     struct aws_client_bootstrap *bootstrap;
 
     /* TLS connection options that have been initialized with your x509 certificate and private key */
-    struct aws_tls_connection_options *tls_connection_options;
+    const struct aws_tls_connection_options *tls_connection_options;
+
     /* IoT thing name you registered with AWS IOT for your device, it will be used in http request header */
     struct aws_byte_cursor thing_name;
+
     /* Iot role alias you created with AWS IoT for your IAM role, it will be used in http request path */
     struct aws_byte_cursor role_alias;
+
     /**
      * AWS account specific endpoint that can be acquired using AWS CLI following instructions from the giving demo
      * example: c2sakl5huz0afv.credentials.iot.us-east-1.amazonaws.com
      */
     struct aws_byte_cursor endpoint;
+
+    /**
+     * (Optional) proxy configuration for the http request that fetches credentials
+     */
+    const struct aws_http_proxy_options *proxy_options;
 
     /* For mocking the http layer in tests, leave NULL otherwise */
     struct aws_credentials_provider_system_vtable *function_table;

--- a/source/credentials_provider_x509.c
+++ b/source/credentials_provider_x509.c
@@ -579,6 +579,7 @@ struct aws_credentials_provider *aws_credentials_provider_new_x509(
     manager_options.shutdown_complete_callback = s_on_connection_manager_shutdown;
     manager_options.shutdown_complete_user_data = provider;
     manager_options.tls_connection_options = &impl->tls_connection_options;
+    manager_options.proxy_options = options->proxy_options;
 
     impl->function_table = options->function_table;
     if (impl->function_table == NULL) {


### PR DESCRIPTION
* Adds proxy support to the x509 credentials provider

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
