### PR TITLE
Flags + decouple iot ws handshake behavior from header skip callback

### DIFF
--- a/include/aws/auth/signing_config.h
+++ b/include/aws/auth/signing_config.h
@@ -23,7 +23,7 @@
 
 struct aws_credentials;
 
-typedef bool(aws_should_sign_param_fn)(const struct aws_byte_cursor *name, void *userdata);
+typedef bool(aws_should_sign_header_fn)(const struct aws_byte_cursor *name, void *userdata);
 
 /**
  * A primitive RTTI indicator for signing configuration structs
@@ -163,28 +163,36 @@ struct aws_signing_config_aws {
     struct aws_date_time date;
 
     /**
-     * Optional function to control which parameters (header or query) are a part of the canonical request.
-     * Skipping auth-required params
-     * will result in an unusable signature.  Headers injected by the signing process are not skippable.
+     * Optional function to control which headers are a part of the canonical request.
+     * Skipping auth-required headers will result in an unusable signature.  Headers injected by the signing process
+     * are not skippable.
      *
      * This function does not override the internal check function (x-amzn-trace-id, user-agent), but rather
      * supplements it.  In particular, a header will get signed if and only if it returns true to both
      * the internal check (skips x-amzn-trace-id, user-agent) and this function (if defined).
      */
-    aws_should_sign_param_fn *should_sign_param;
-    void *should_sign_param_ud;
+    aws_should_sign_header_fn *should_sign_header;
+    void *should_sign_header_ud;
 
-    /**
-     * We assume the uri will be encoded once in preparation for transmission.  Certain services
-     * do not decode before checking signature, requiring us to actually double-encode the uri in the canonical request
-     * in order to pass a signature check.
-     */
-    bool use_double_uri_encode;
+    struct {
+        /**
+         * We assume the uri will be encoded once in preparation for transmission.  Certain services
+         * do not decode before checking signature, requiring us to actually double-encode the uri in the canonical
+         * request in order to pass a signature check.
+         */
+        uint32_t use_double_uri_encode : 1;
 
-    /**
-     * Controls whether or not the uri paths should be normalized when building the canonical request
-     */
-    bool should_normalize_uri_path;
+        /**
+         * Controls whether or not the uri paths should be normalized when building the canonical request
+         */
+        uint32_t should_normalize_uri_path : 1;
+
+        /**
+         * Should the sesssion token query param be omitted from the canonical request?  This is a special case that
+         * should only be true when performing a websocket handshake to succcessfully authenticate to iot core.
+         */
+        uint32_t omit_session_token_query_param : 1;
+    } flags;
 
     /**
      * Controls what should be used as "the body" when creating the canonical request.

--- a/source/credentials_provider_sts.c
+++ b/source/credentials_provider_sts.c
@@ -569,7 +569,7 @@ static void s_start_make_request(
     aws_date_time_init_now(&provider_user_data->signing_config.date);
     provider_user_data->signing_config.region = s_signing_region;
     provider_user_data->signing_config.service = s_service_name;
-    provider_user_data->signing_config.use_double_uri_encode = false;
+    provider_user_data->signing_config.flags.use_double_uri_encode = false;
 
     if (aws_sign_request_aws(
             provider->allocator,

--- a/source/sigv4_http_request.c
+++ b/source/sigv4_http_request.c
@@ -445,8 +445,8 @@ int aws_sign_http_request_sigv4(struct aws_http_message *request, struct aws_all
     config.signature_type = AWS_ST_HTTP_REQUEST_HEADERS;
     config.region = aws_byte_cursor_from_string(region);
     config.service = aws_byte_cursor_from_string(service);
-    config.use_double_uri_encode = true;
-    config.should_normalize_uri_path = true;
+    config.flags.use_double_uri_encode = true;
+    config.flags.should_normalize_uri_path = true;
     config.signed_body_value = AWS_SBVT_EMPTY;
 
     aws_date_time_init_now(&config.date);

--- a/tests/sigv4_tests.c
+++ b/tests/sigv4_tests.c
@@ -240,8 +240,8 @@ static int s_initialize_test_from_contents(
     config->signature_type = AWS_ST_HTTP_REQUEST_HEADERS;
     config->region = aws_byte_cursor_from_string(s_test_suite_region);
     config->service = aws_byte_cursor_from_string(s_test_suite_service);
-    config->use_double_uri_encode = true;
-    config->should_normalize_uri_path = true;
+    config->flags.use_double_uri_encode = true;
+    config->flags.should_normalize_uri_path = true;
     config->signed_body_value = AWS_SBVT_EMPTY;
     config->signed_body_header = AWS_SBHT_NONE;
 
@@ -651,7 +651,7 @@ DECLARE_SIGV4_TEST_SUITE_CASE(post_x_www_form_urlencoded_parameters, "post-x-www
 
 static int s_do_header_skip_test(
     struct aws_allocator *allocator,
-    aws_should_sign_param_fn *should_sign,
+    aws_should_sign_header_fn *should_sign,
     const struct aws_string *request_contents,
     const struct aws_string *expected_canonical_request) {
 
@@ -673,7 +673,7 @@ static int s_do_header_skip_test(
             &signable, &config, allocator, &test_contents, &request_cursor, &expected_canonical_request_cursor, true) ==
         AWS_OP_SUCCESS);
 
-    config.should_sign_param = should_sign;
+    config.should_sign_header = should_sign;
 
     struct aws_credentials *credentials = aws_credentials_new_from_string(
         allocator, s_test_suite_access_key_id, s_test_suite_secret_access_key, NULL, UINT64_MAX);

--- a/tests/test_chunked_signing.c
+++ b/tests/test_chunked_signing.c
@@ -92,8 +92,8 @@ static int s_initialize_request_signing_config(
         return AWS_OP_ERR;
     }
 
-    config->use_double_uri_encode = false;
-    config->should_normalize_uri_path = true;
+    config->flags.use_double_uri_encode = false;
+    config->flags.should_normalize_uri_path = true;
     config->signed_body_value = AWS_SBVT_STREAMING_AWS4_HMAC_SHA256_PAYLOAD;
     config->signed_body_header = AWS_SBHT_X_AMZ_CONTENT_SHA256;
     config->credentials = credentials;
@@ -115,8 +115,8 @@ static int s_initialize_chunk_signing_config(
         return AWS_OP_ERR;
     }
 
-    config->use_double_uri_encode = false;
-    config->should_normalize_uri_path = true;
+    config->flags.use_double_uri_encode = false;
+    config->flags.should_normalize_uri_path = true;
     config->signed_body_value = AWS_SBVT_PAYLOAD;
     config->signed_body_header = AWS_SBHT_NONE;
     config->credentials = credentials;


### PR DESCRIPTION
* Move signing config bools into a flags bitfield
* Decouple header skipping from not adding the session token to the canonical request of an iot websocket handshake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
