### PR TITLE
Fix S3 query param signing

### DIFF
--- a/source/aws_signing.c
+++ b/source/aws_signing.c
@@ -869,7 +869,7 @@ static int s_append_canonical_query_string(struct aws_uri *uri, struct aws_signi
         }
 
         if (s_append_canonical_query_param(
-                &param, canonical_request_buffer, state->config.flags.use_double_uri_encode)) {
+                &param, canonical_request_buffer, (bool)state->config.flags.use_double_uri_encode)) {
             goto cleanup;
         }
 


### PR DESCRIPTION
if not double-encoding URI, don't double-encode query params either

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
