### PR TITLE
Suppress compiler warning C4232 for MSVC

### DIFF
--- a/source/aws_imds_client.c
+++ b/source/aws_imds_client.c
@@ -28,6 +28,7 @@
 
 #if defined(_MSC_VER)
 #    pragma warning(disable : 4204)
+#    pragma warning(disable : 4232)
 #endif /* _MSC_VER */
 
 /* instance role credentials body response is currently ~ 1300 characters + name length */

--- a/source/credentials_provider_ecs.c
+++ b/source/credentials_provider_ecs.c
@@ -31,6 +31,7 @@
 
 #if defined(_MSC_VER)
 #    pragma warning(disable : 4204)
+#    pragma warning(disable : 4232)
 #endif /* _MSC_VER */
 
 /* ecs task role credentials body response is currently ~ 1300 characters + name length */

--- a/source/credentials_provider_sts.c
+++ b/source/credentials_provider_sts.c
@@ -42,6 +42,8 @@
 #    pragma warning(disable : 4204)
 /* allow passing of address of automatic variable */
 #    pragma warning(disable : 4221)
+/* function pointer to dll symbol */
+#    pragma warning(disable : 4232)
 #endif
 
 static struct aws_http_header s_host_header = {

--- a/source/credentials_provider_sts_web_identity.c
+++ b/source/credentials_provider_sts_web_identity.c
@@ -38,6 +38,7 @@
 
 #if defined(_MSC_VER)
 #    pragma warning(disable : 4204)
+#    pragma warning(disable : 4232)
 #endif /* _MSC_VER */
 
 #define STS_WEB_IDENTITY_RESPONSE_SIZE_INITIAL 2048

--- a/source/credentials_provider_x509.c
+++ b/source/credentials_provider_x509.c
@@ -31,6 +31,7 @@
 
 #if defined(_MSC_VER)
 #    pragma warning(disable : 4204)
+#    pragma warning(disable : 4232)
 #endif /* _MSC_VER */
 
 /* IoT Core credentials body response is currently ~ 1100 Bytes*/


### PR DESCRIPTION
**Issue:**
Encountered compiler warning [C4232](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4232?view=vs-2019) when building aws-c-auth as shared library on Windows:
> nonstandard extension used : 'identifier' : address of dllimport 'dllimport' is not static, identity not guaranteed.

The following definitions are impacted:
```c
/* In aws_imds_client.c,
      credentials_provider_ecs.c,
      credentials_provider_sts.c,
      credentials_provider_sts_web_identity.c
and   credentials_provider_x509.c */
static struct aws_auth_http_system_vtable s_default_function_table = {
    .aws_http_connection_manager_new = aws_http_connection_manager_new,
    .aws_http_connection_manager_release = aws_http_connection_manager_release,
    .aws_http_connection_manager_acquire_connection = aws_http_connection_manager_acquire_connection,
    .aws_http_connection_manager_release_connection = aws_http_connection_manager_release_connection,
    .aws_http_connection_make_request = aws_http_connection_make_request,
    .aws_http_stream_activate = aws_http_stream_activate,
    .aws_http_stream_get_connection = aws_http_stream_get_connection,
    .aws_http_stream_get_incoming_response_status = aws_http_stream_get_incoming_response_status,
    .aws_http_stream_release = aws_http_stream_release,
    .aws_http_connection_close = aws_http_connection_close,
};
```

**Description of changes:**
Disable warning C4232 before using function pointer to dll symbol.
```c
#if _MSC_VER
#    pragma warning(disable : 4232) /* function pointer to dll symbol */
#endif
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
