### PR TITLE
Update ref count APIs to take const

### DIFF
--- a/include/aws/auth/credentials.h
+++ b/include/aws/auth/credentials.h
@@ -458,7 +458,7 @@ struct aws_credentials *aws_credentials_new_from_string(
  * @param credentials credentials to increment the ref count on
  */
 AWS_AUTH_API
-void aws_credentials_acquire(struct aws_credentials *credentials);
+void aws_credentials_acquire(const struct aws_credentials *credentials);
 
 /**
  * Remove a reference to some credentials
@@ -466,7 +466,7 @@ void aws_credentials_acquire(struct aws_credentials *credentials);
  * @param credentials credentials to decrement the ref count on
  */
 AWS_AUTH_API
-void aws_credentials_release(struct aws_credentials *credentials);
+void aws_credentials_release(const struct aws_credentials *credentials);
 
 /**
  * Get the AWS access key id from a set of credentials

--- a/include/aws/auth/signing_config.h
+++ b/include/aws/auth/signing_config.h
@@ -211,7 +211,7 @@ struct aws_signing_config_aws {
     /**
      * AWS Credentials to sign with.
      */
-    struct aws_credentials *credentials;
+    const struct aws_credentials *credentials;
 
     /**
      * AWS credentials provider to fetch credentials from.

--- a/source/credentials.c
+++ b/source/credentials.c
@@ -132,22 +132,22 @@ static void s_aws_credentials_destroy(struct aws_credentials *credentials) {
     aws_mem_release(credentials->allocator, credentials);
 }
 
-void aws_credentials_acquire(struct aws_credentials *credentials) {
+void aws_credentials_acquire(const struct aws_credentials *credentials) {
     if (credentials == NULL) {
         return;
     }
 
-    aws_atomic_fetch_add(&credentials->ref_count, 1);
+    aws_atomic_fetch_add((struct aws_atomic_var *)&credentials->ref_count, 1);
 }
 
-void aws_credentials_release(struct aws_credentials *credentials) {
+void aws_credentials_release(const struct aws_credentials *credentials) {
     if (credentials == NULL) {
         return;
     }
 
-    size_t old_value = aws_atomic_fetch_sub(&credentials->ref_count, 1);
+    size_t old_value = aws_atomic_fetch_sub((struct aws_atomic_var *)&credentials->ref_count, 1);
     if (old_value == 1) {
-        s_aws_credentials_destroy(credentials);
+        s_aws_credentials_destroy((struct aws_credentials *)credentials);
     }
 }
 


### PR DESCRIPTION
* Fix for aws_credentials ref count API to take const objects (move from strict-const to intent-const)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
