### PR TITLE
Handle empty stream when computing the canonical request payload value.

### DIFF
--- a/source/aws_signing.c
+++ b/source/aws_signing.c
@@ -1370,7 +1370,12 @@ static int s_build_canonical_payload(struct aws_signing_state_aws *state) {
             goto on_cleanup;
         }
 
+        int64_t payload_stream_length = 0;
         if (payload_stream != NULL) {
+            aws_input_stream_get_length(payload_stream, &payload_stream_length);
+        }
+
+        if (payload_stream_length) {
             if (aws_input_stream_seek(payload_stream, 0, AWS_SSB_BEGIN)) {
                 goto on_cleanup;
             }


### PR DESCRIPTION
*Issue:*
For empty payload stream in `s_build_canonical_payload()`
it will `goto on_cleanup` immediately then returns `AWS_OP_ERR`, because `aws_input_stream_read()` returns non zero for empty stream:
```c++
if (aws_input_stream_read(payload_stream, &body_buffer)) {
    goto on_cleanup;
}
```

*Description of changes:*
The fix is just do nothing with empty stream.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
