### PR TITLE
tests: Fix multiple definition of s_tester variable.

### DIFF
--- a/tests/credentials_provider_process_tests.c
+++ b/tests/credentials_provider_process_tests.c
@@ -15,7 +15,7 @@
 #include <aws/common/string.h>
 #include <aws/io/logging.h>
 
-struct aws_mock_process_tester {
+static struct aws_mock_process_tester {
     struct aws_mutex lock;
     struct aws_condition_variable signal;
     struct aws_credentials *credentials;

--- a/tests/credentials_provider_sts_web_identity_tests.c
+++ b/tests/credentials_provider_sts_web_identity_tests.c
@@ -23,7 +23,7 @@
 #include <aws/io/stream.h>
 #include <aws/io/tls_channel_handler.h>
 
-struct aws_mock_sts_web_identity_tester {
+static struct aws_mock_sts_web_identity_tester {
     struct aws_byte_buf request_body;
 
     struct aws_array_list response_data_callbacks;


### PR DESCRIPTION
The same variable is used in credentials_provider_process_tests.c
and credentials_provider_sts_web_identity_tests.c file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
