### PR TITLE
Using snprintf over sprintf

### DIFF
--- a/source/external/cJSON.c
+++ b/source/external/cJSON.c
@@ -954,7 +954,7 @@ static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffe
                     break;
                 default:
                     /* escape and print as unicode codepoint */
-                    snprintf((char*)output_pointer, 4 * sizeof(char), "u%04x", *input_pointer);
+                    snprintf((char*)output_pointer, 6 * sizeof(char), "u%04x", *input_pointer);
                     output_pointer += 4;
                     break;
             }

--- a/source/external/cJSON.c
+++ b/source/external/cJSON.c
@@ -510,18 +510,18 @@ static cJSON_bool print_number(const cJSON * const item, printbuffer * const out
     /* This checks for NaN and Infinity */
     if ((d * 0) != 0)
     {
-        length = sprintf((char*)number_buffer, "null");
+        length = snprintf((char*)number_buffer, sizeof(number_buffer) / sizeof(char), "null");
     }
     else
     {
         /* Try 15 decimal places of precision to avoid nonsignificant nonzero digits */
-        length = sprintf((char*)number_buffer, "%1.15g", d);
+        length = snprintf((char*)number_buffer, sizeof(number_buffer) / sizeof(char), "%1.15g", d);
 
         /* Check whether the original double can be recovered */
         if ((sscanf((char*)number_buffer, "%lg", &test) != 1) || ((double)test != d))
         {
             /* If not, print with 17 decimal places of precision */
-            length = sprintf((char*)number_buffer, "%1.17g", d);
+            length = snprintf((char*)number_buffer, sizeof(number_buffer) / sizeof(char), "%1.17g", d);
         }
     }
 
@@ -954,7 +954,7 @@ static cJSON_bool print_string_ptr(const unsigned char * const input, printbuffe
                     break;
                 default:
                     /* escape and print as unicode codepoint */
-                    sprintf((char*)output_pointer, "u%04x", *input_pointer);
+                    snprintf((char*)output_pointer, 4 * sizeof(char), "u%04x", *input_pointer);
                     output_pointer += 4;
                     break;
             }


### PR DESCRIPTION
*Description of changes:*
* Using safer function snprintf over sprintf in cJSON

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
