### PR TITLE
Ecs credentials provider fixes

### DIFF
--- a/source/credentials_provider_default_chain.c
+++ b/source/credentials_provider_default_chain.c
@@ -96,7 +96,7 @@ static struct aws_credentials_provider *s_aws_credentials_provider_new_ecs_or_im
         };
 
         ecs_or_imds_provider = aws_credentials_provider_new_ecs(allocator, &ecs_options);
-
+        aws_uri_clean_up(&uri);
     } else if (ec2_imds_disable == NULL || aws_string_eq_c_str_ignore_case(ec2_imds_disable, "false")) {
         struct aws_credentials_provider_imds_options imds_options = {
             .shutdown_options = *shutdown_options,

--- a/source/credentials_provider_ecs.c
+++ b/source/credentials_provider_ecs.c
@@ -471,6 +471,7 @@ static void s_credentials_provider_ecs_destroy(struct aws_credentials_provider *
 
     aws_string_destroy(impl->path_and_query);
     aws_string_destroy(impl->auth_token);
+    aws_string_destory(impl->host);
 
     /* aws_http_connection_manager_release will eventually leads to call of s_on_connection_manager_shutdown,
      * which will do memory release for provider and impl. So We should be freeing impl
@@ -567,13 +568,12 @@ struct aws_credentials_provider *aws_credentials_provider_new_ecs(
         goto on_error;
     }
     if (options->auth_token.len != 0) {
-        impl->auth_token = aws_string_new_from_array(allocator, options->auth_token.ptr, options->auth_token.len);
+        impl->auth_token = aws_string_new_from_cursor(allocator, &options->auth_token);
         if (impl->auth_token == NULL) {
             goto on_error;
         }
     }
-    impl->path_and_query =
-        aws_string_new_from_array(allocator, options->path_and_query.ptr, options->path_and_query.len);
+    impl->path_and_query = aws_string_new_from_cursor(allocator, &options->path_and_query);
     if (impl->path_and_query == NULL) {
         goto on_error;
     }

--- a/source/credentials_provider_ecs.c
+++ b/source/credentials_provider_ecs.c
@@ -471,7 +471,7 @@ static void s_credentials_provider_ecs_destroy(struct aws_credentials_provider *
 
     aws_string_destroy(impl->path_and_query);
     aws_string_destroy(impl->auth_token);
-    aws_string_destory(impl->host);
+    aws_string_destroy(impl->host);
 
     /* aws_http_connection_manager_release will eventually leads to call of s_on_connection_manager_shutdown,
      * which will do memory release for provider and impl. So We should be freeing impl


### PR DESCRIPTION
* Fix ecs credentials provider by massaging request construction:
* * Add Host and Accept-Encoding headers
* * Modify Accept header although it's probably not an issue
* * Always add Authorization header if the environment variable is set (matches other implementations)
* * Don't add keep alive header
* * Fix memory leak in ecs code path due to not cleaning up uri object

https://github.com/awslabs/aws-c-auth/issues/119

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
