### PR TITLE
Ensure that aws-c-sdkutils is added as a dependency for downstream deps

### DIFF
--- a/cmake/aws-c-auth-config.cmake
+++ b/cmake/aws-c-auth-config.cmake
@@ -4,6 +4,7 @@ find_dependency(aws-c-common)
 find_dependency(aws-c-cal)
 find_dependency(aws-c-io)
 find_dependency(aws-c-http)
+find_dependency(aws-c-sdkutils)
 
 if (BUILD_SHARED_LIBS)
     include(${CMAKE_CURRENT_LIST_DIR}/shared/@PROJECT_NAME@-targets.cmake)


### PR DESCRIPTION
Fixes: 
* https://github.com/awslabs/aws-c-s3/pull/149

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
