### PR TITLE
First pass on ECS port override support 

### DIFF
--- a/include/aws/auth/credentials.h
+++ b/include/aws/auth/credentials.h
@@ -256,6 +256,11 @@ struct aws_credentials_provider_ecs_options {
 
     /* For mocking the http layer in tests, leave NULL otherwise */
     struct aws_auth_http_system_vtable *function_table;
+
+    /*
+     * Port to query credentials from.  If zero, 80/443 will be used based on whether or not tls is enabled.
+     */
+    uint16_t port;
 };
 
 /**

--- a/source/credentials_provider_default_chain.c
+++ b/source/credentials_provider_default_chain.c
@@ -93,6 +93,7 @@ static struct aws_credentials_provider *s_aws_credentials_provider_new_ecs_or_im
             .path_and_query = uri.path_and_query,
             .tls_ctx = aws_byte_cursor_eq_c_str_ignore_case(&(uri.scheme), "HTTPS") ? tls_ctx : NULL,
             .auth_token = auth_token_cursor,
+            .port = uri.port,
         };
 
         ecs_or_imds_provider = aws_credentials_provider_new_ecs(allocator, &ecs_options);

--- a/source/credentials_provider_ecs.c
+++ b/source/credentials_provider_ecs.c
@@ -552,7 +552,11 @@ struct aws_credentials_provider *aws_credentials_provider_new_ecs(
     manager_options.initial_window_size = ECS_RESPONSE_SIZE_LIMIT;
     manager_options.socket_options = &socket_options;
     manager_options.host = options->host;
-    manager_options.port = options->tls_ctx ? 443 : 80;
+    if (options->port == 0) {
+        manager_options.port = options->tls_ctx ? 443 : 80;
+    } else {
+        manager_options.port = options->port;
+    }
     manager_options.max_connections = 2;
     manager_options.shutdown_complete_callback = s_on_connection_manager_shutdown;
     manager_options.shutdown_complete_user_data = provider;


### PR DESCRIPTION
* ecs port override support
* includes default credentials provider update
* memory model correctness updates in ecs mock tests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
