### PR TITLE
call aws_sdkutils_library_init()

### DIFF
--- a/source/auth.c
+++ b/source/auth.c
@@ -11,6 +11,8 @@
 
 #include <aws/http/http.h>
 
+#include <aws/sdkutils/sdkutils.h>
+
 #include <aws/common/error.h>
 
 #define AWS_DEFINE_ERROR_INFO_AUTH(CODE, STR) AWS_DEFINE_ERROR_INFO(CODE, STR, "aws-c-auth")
@@ -131,6 +133,7 @@ void aws_auth_library_init(struct aws_allocator *allocator) {
         s_library_allocator = aws_default_allocator();
     }
 
+    aws_sdkutils_library_init(s_library_allocator);
     aws_cal_library_init(s_library_allocator);
     aws_http_library_init(s_library_allocator);
 
@@ -158,5 +161,6 @@ void aws_auth_library_clean_up(void) {
     aws_unregister_error_info(&s_error_list);
     aws_http_library_clean_up();
     aws_cal_library_clean_up();
+    aws_sdkutils_library_clean_up();
     s_library_allocator = NULL;
 }


### PR DESCRIPTION
**Issue:**
Error codes and logger IDs from aws-c-sdkutils weren't being registered

**Description of changes:**
call aws_sdkutils_library_init() & clean_up() 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
