### PR TITLE
cached provider: honor STS expiration time

### DIFF
--- a/source/credentials_provider_cached.c
+++ b/source/credentials_provider_cached.c
@@ -109,17 +109,13 @@ static void s_cached_credentials_provider_get_credentials_async_callback(
                     aws_timestamp_convert(system_now, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_SECS, NULL);
                 if (credentials_expiration_timepoint_seconds >=
                     system_now_seconds + REFRESH_CREDENTIALS_EARLY_DURATION_SECONDS) {
-                    uint64_t early_refresh_time_ns = high_res_now;
-                    early_refresh_time_ns += aws_timestamp_convert(
+                    next_refresh_time_in_ns = high_res_now;
+                    next_refresh_time_in_ns += aws_timestamp_convert(
                         credentials_expiration_timepoint_seconds - system_now_seconds -
                             REFRESH_CREDENTIALS_EARLY_DURATION_SECONDS,
                         AWS_TIMESTAMP_SECS,
                         AWS_TIMESTAMP_NANOS,
                         NULL);
-
-                    if (early_refresh_time_ns < next_refresh_time_in_ns) {
-                        next_refresh_time_in_ns = early_refresh_time_ns;
-                    }
                 }
             }
         }


### PR DESCRIPTION
The cached credentials provider will only adjust its refresh interval when caching STS
web identity credentials (expiration_timepoint_seconds < UINT_MAX).

STS credentials are typically valid for 1h. The default refresh interval used by the default
chain provider for caching credentials is 15 minutes (`DEFAULT_CREDENTIAL_PROVIDER_REFRESH_MS`).


Currently the cached credentials provider will only adjust its refresh interval if the
STS credentials expire within its refresh interval (via if-condition).

Consequently, the cached provider will refresh STS credentials 4 times more frequently than
required, increasing the load on the STS endpoint. This causes issues for large parallel
workloads, such as throttling STS requests.

Hence honor the longer expiration interval where possible.

*Issue #, if available:*

*Description of changes:*
Let the cached credentials provider accept the expiration suggested by the cached (STS) credentials,
not the (shorter) refresh interval.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
