### PR TITLE
Never sign "Expect" header

### DIFF
--- a/source/aws_signing.c
+++ b/source/aws_signing.c
@@ -130,6 +130,11 @@ int aws_signing_init_signing_tables(struct aws_allocator *allocator) {
         return AWS_OP_ERR;
     }
 
+    s_connection_header_name = aws_byte_cursor_from_c_str("expect");
+    if (aws_hash_table_put(&s_skipped_headers, &s_connection_header_name, NULL, NULL)) {
+        return AWS_OP_ERR;
+    }
+
     s_sec_websocket_key_header_name = aws_byte_cursor_from_c_str("sec-websocket-key");
     if (aws_hash_table_put(&s_skipped_headers, &s_sec_websocket_key_header_name, NULL, NULL)) {
         return AWS_OP_ERR;


### PR DESCRIPTION
The "Expect" header should always be skipped during SigV4 signing.

AWS SDK for Java informed us that there are 4 headers they always skip. "Expect" is the only one we were missing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
