### PR TITLE
Fix Trailer Signing

### DIFF
--- a/include/aws/auth/signable.h
+++ b/include/aws/auth/signable.h
@@ -215,7 +215,7 @@ AWS_AUTH_API
 struct aws_signable *aws_signable_new_trailing_headers(
     struct aws_allocator *allocator,
     struct aws_http_headers *trailing_headers,
-    const struct aws_byte_cursor previous_signature);
+    struct aws_byte_cursor previous_signature);
 
 /**
  * Creates a signable that represents a pre-computed canonical request from an http request

--- a/include/aws/auth/signable.h
+++ b/include/aws/auth/signable.h
@@ -214,7 +214,7 @@ struct aws_signable *aws_signable_new_chunk(
 AWS_AUTH_API
 struct aws_signable *aws_signable_new_trailing_headers(
     struct aws_allocator *allocator,
-    const struct aws_http_headers *trailing_headers,
+    struct aws_http_headers *trailing_headers,
     const struct aws_byte_cursor previous_signature);
 
 /**

--- a/include/aws/auth/signable.h
+++ b/include/aws/auth/signable.h
@@ -214,8 +214,8 @@ struct aws_signable *aws_signable_new_chunk(
 AWS_AUTH_API
 struct aws_signable *aws_signable_new_trailing_headers(
     struct aws_allocator *allocator,
-    struct aws_http_headers *trailing_headers,
-    struct aws_byte_cursor previous_signature);
+    const struct aws_http_headers *trailing_headers,
+    const struct aws_byte_cursor previous_signature);
 
 /**
  * Creates a signable that represents a pre-computed canonical request from an http request

--- a/source/signable_trailer.c
+++ b/source/signable_trailer.c
@@ -72,6 +72,7 @@ static void s_aws_signable_trailing_headers_destroy(struct aws_signable *signabl
     if (impl == NULL) {
         return;
     }
+
     aws_http_headers_release(impl->trailing_headers);
     aws_string_destroy(impl->previous_signature);
     aws_array_list_clean_up(&impl->headers);
@@ -97,6 +98,7 @@ struct aws_signable *aws_signable_new_trailing_headers(
 
     AWS_ZERO_STRUCT(*signable);
     AWS_ZERO_STRUCT(*impl);
+
     aws_http_headers_acquire(trailing_headers);
     impl->trailing_headers = trailing_headers;
     signable->allocator = allocator;
@@ -104,7 +106,7 @@ struct aws_signable *aws_signable_new_trailing_headers(
     signable->impl = impl;
 
     /*
-     * Convert headers list to aws_signable_property_list_pair array list.
+     * Convert headers list to aws_signable_property_list_pair arraylist.
      */
     size_t header_count = aws_http_headers_count(trailing_headers);
     if (aws_array_list_init_dynamic(

--- a/source/signable_trailer.c
+++ b/source/signable_trailer.c
@@ -117,6 +117,7 @@ struct aws_signable *aws_signable_new_trailing_headers(
     for (size_t i = 0; i < header_count; ++i) {
         struct aws_http_header header;
         aws_http_headers_get_index(trailing_headers, i, &header);
+
         struct aws_signable_property_list_pair property = {.name = header.name, .value = header.value};
         aws_array_list_push_back(&impl->headers, &property);
     }

--- a/source/signable_trailer.c
+++ b/source/signable_trailer.c
@@ -99,6 +99,7 @@ struct aws_signable *aws_signable_new_trailing_headers(
     AWS_ZERO_STRUCT(*signable);
     AWS_ZERO_STRUCT(*impl);
 
+    /* Keep the headers alive. We're referencing the underlying strings. */
     aws_http_headers_acquire(trailing_headers);
     impl->trailing_headers = trailing_headers;
     signable->allocator = allocator;

--- a/source/signable_trailer.c
+++ b/source/signable_trailer.c
@@ -88,7 +88,7 @@ static struct aws_signable_vtable s_signable_trailing_headers_vtable = {
 
 struct aws_signable *aws_signable_new_trailing_headers(
     struct aws_allocator *allocator,
-    const struct aws_http_headers *trailing_headers,
+    struct aws_http_headers *trailing_headers,
     const struct aws_byte_cursor previous_signature) {
 
     struct aws_signable *signable = NULL;

--- a/source/signable_trailer.c
+++ b/source/signable_trailer.c
@@ -106,7 +106,7 @@ struct aws_signable *aws_signable_new_trailing_headers(
     signable->impl = impl;
 
     /*
-     * Convert headers list to aws_signable_property_list_pair arraylist.
+     * Convert headers list to aws_signable_property_list_pair arraylist since they're not different types.
      */
     size_t header_count = aws_http_headers_count(trailing_headers);
     if (aws_array_list_init_dynamic(

--- a/source/signable_trailer.c
+++ b/source/signable_trailer.c
@@ -89,7 +89,7 @@ static struct aws_signable_vtable s_signable_trailing_headers_vtable = {
 struct aws_signable *aws_signable_new_trailing_headers(
     struct aws_allocator *allocator,
     struct aws_http_headers *trailing_headers,
-    const struct aws_byte_cursor previous_signature) {
+    struct aws_byte_cursor previous_signature) {
 
     struct aws_signable *signable = NULL;
     struct aws_signable_trailing_headers_impl *impl = NULL;

--- a/source/signable_trailer.c
+++ b/source/signable_trailer.c
@@ -88,8 +88,8 @@ static struct aws_signable_vtable s_signable_trailing_headers_vtable = {
 
 struct aws_signable *aws_signable_new_trailing_headers(
     struct aws_allocator *allocator,
-    struct aws_http_headers *trailing_headers,
-    struct aws_byte_cursor previous_signature) {
+    const struct aws_http_headers *trailing_headers,
+    const struct aws_byte_cursor previous_signature) {
 
     struct aws_signable *signable = NULL;
     struct aws_signable_trailing_headers_impl *impl = NULL;


### PR DESCRIPTION
*Description of changes:*
- `aws_signable_new_trailing_headers` should acquire trailer headers as it doesn't makes a deep copy of byte cursor.
- Update test to cater this use case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
