### PR TITLE
Fix aws_parse_credentials_from_json_document

### DIFF
--- a/include/aws/auth/private/credentials_utils.h
+++ b/include/aws/auth/private/credentials_utils.h
@@ -154,7 +154,7 @@ struct aws_credentials *aws_parse_credentials_from_aws_json_object(
 AWS_AUTH_API
 struct aws_credentials *aws_parse_credentials_from_json_document(
     struct aws_allocator *allocator,
-    const char *json_document,
+    struct aws_byte_cursor json_document,
     const struct aws_parse_credentials_from_json_doc_options *options);
 
 AWS_AUTH_API

--- a/source/aws_imds_client.c
+++ b/source/aws_imds_client.c
@@ -1039,7 +1039,7 @@ static void s_process_credentials_resource(const struct aws_byte_buf *resource, 
     };
 
     credentials = aws_parse_credentials_from_json_document(
-        wrapped_user_data->allocator, (const char *)json_data.buffer, &parse_options);
+        wrapped_user_data->allocator, aws_byte_cursor_from_buf(&json_data), &parse_options);
 
 on_finish:
     wrapped_user_data->callback(credentials, error_code, wrapped_user_data->user_data);

--- a/source/credentials_provider_ecs.c
+++ b/source/credentials_provider_ecs.c
@@ -145,7 +145,7 @@ static void s_ecs_finalize_get_credentials_query(struct aws_credentials_provider
     };
     if (aws_byte_buf_append_null_terminator(&ecs_user_data->current_result) == AWS_OP_SUCCESS) {
         credentials = aws_parse_credentials_from_json_document(
-            ecs_user_data->allocator, (const char *)ecs_user_data->current_result.buffer, &parse_options);
+            ecs_user_data->allocator, aws_byte_cursor_from_buf(&ecs_user_data->current_result), &parse_options);
     } else {
         AWS_LOGF_ERROR(
             AWS_LS_AUTH_CREDENTIALS_PROVIDER,

--- a/source/credentials_provider_process.c
+++ b/source/credentials_provider_process.c
@@ -56,8 +56,8 @@ static int s_get_credentials_from_process(
         .expiration_required = false,
     };
 
-    credentials =
-        aws_parse_credentials_from_json_document(provider->allocator, aws_string_c_str(result.std_out), &parse_options);
+    credentials = aws_parse_credentials_from_json_document(
+        provider->allocator, aws_byte_cursor_from_string(result.std_out), &parse_options);
     if (!credentials) {
         AWS_LOGF_INFO(
             AWS_LS_AUTH_CREDENTIALS_PROVIDER,

--- a/source/credentials_utils.c
+++ b/source/credentials_utils.c
@@ -251,11 +251,10 @@ done:
 
 struct aws_credentials *aws_parse_credentials_from_json_document(
     struct aws_allocator *allocator,
-    const char *document,
+    struct aws_byte_cursor document,
     const struct aws_parse_credentials_from_json_doc_options *options) {
 
-    struct aws_json_value *document_root =
-        aws_json_value_new_from_string(allocator, aws_byte_cursor_from_c_str(document));
+    struct aws_json_value *document_root = aws_json_value_new_from_string(allocator, document);
     if (document_root == NULL) {
         AWS_LOGF_ERROR(AWS_LS_AUTH_CREDENTIALS_PROVIDER, "Failed to parse document as Json document.");
         return NULL;


### PR DESCRIPTION
*Description of changes:*
- Use `aws_byte_cursor` instead of `char *`, as `aws_byte_buf` doesn't have to be null terminated, so converting it to a `char *` is not safe.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
