### PR TITLE
don't use the default cursor to override if no override needed

### DIFF
--- a/source/credentials_provider_process.c
+++ b/source/credentials_provider_process.c
@@ -100,7 +100,6 @@ static void s_credentials_provider_process_destroy(struct aws_credentials_provid
 }
 
 AWS_STATIC_STRING_FROM_LITERAL(s_credentials_process, "credential_process");
-static struct aws_byte_cursor s_default_profile_name_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("default");
 
 static struct aws_profile_collection *s_load_profile(struct aws_allocator *allocator) {
 
@@ -167,7 +166,7 @@ static struct aws_string *s_get_command(struct aws_allocator *allocator, struct 
 
     config_profiles = s_load_profile(allocator);
     if (profile_cursor.len == 0) {
-        profile_name = aws_get_profile_name(allocator, &s_default_profile_name_cursor);
+        profile_name = aws_get_profile_name(allocator, NULL);
     } else {
         profile_name = aws_string_new_from_array(allocator, profile_cursor.ptr, profile_cursor.len);
     }

--- a/source/credentials_provider_sts_web_identity.c
+++ b/source/credentials_provider_sts_web_identity.c
@@ -846,7 +846,6 @@ on_error:
     return NULL;
 }
 
-static struct aws_byte_cursor s_default_profile_name_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("default");
 static struct aws_byte_cursor s_dot_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(".");
 static struct aws_byte_cursor s_amazonaws_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(".amazonaws.com");
 static struct aws_byte_cursor s_cn_cursor = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL(".cn");
@@ -1001,7 +1000,7 @@ static struct sts_web_identity_parameters *s_parameters_new(
             }
         }
 
-        profile_name = aws_get_profile_name(allocator, &s_default_profile_name_cursor);
+        profile_name = aws_get_profile_name(allocator, NULL);
         if (profile_name) {
             profile = aws_profile_collection_get_profile(config_profile, profile_name);
         }

--- a/tests/aws_profile_tests.c
+++ b/tests/aws_profile_tests.c
@@ -94,9 +94,6 @@ AWS_STATIC_STRING_FROM_LITERAL(s_profile_override, "NotTheDefault");
 static int s_profile_override_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
-    /* Make sure the environment doesn't affect this test */
-    aws_unset_environment_value(s_profile_env_var);
-
     struct aws_byte_cursor override_cursor = aws_byte_cursor_from_string(s_profile_override);
     struct aws_string *profile_name = aws_get_profile_name(allocator, &override_cursor);
     ASSERT_TRUE(aws_string_compare(profile_name, s_profile_override) == 0);


### PR DESCRIPTION
- as we change the behavior to take the provided profile override the environment variable, we cannot use a provided `default` cursor
- We don't need to at the first place, it will take the environment variable if exist, otherwise, fallback to `default`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
