### PR TITLE
Fix session token in ProcessCredentialsProvider

### DIFF
--- a/source/credentials_provider_process.c
+++ b/source/credentials_provider_process.c
@@ -50,7 +50,7 @@ static int s_get_credentials_from_process(
     struct aws_parse_credentials_from_json_doc_options parse_options = {
         .access_key_id_name = "AccessKeyId",
         .secret_access_key_name = "SecretAccessKey",
-        .token_name = "Token",
+        .token_name = "SessionToken",
         .expiration_name = "Expiration",
         .token_required = false,
         .expiration_required = false,

--- a/tests/credentials_provider_process_tests.c
+++ b/tests/credentials_provider_process_tests.c
@@ -120,13 +120,13 @@ static void s_get_credentials_callback(struct aws_credentials *credentials, int 
 AWS_STATIC_STRING_FROM_LITERAL(
     s_test_command,
     "echo {\"Version\": 1, \"AccessKeyId\": \"AccessKey123\", "
-    "\"SecretAccessKey\": \"SecretAccessKey321\", \"Token\":\"TokenSuccess\", "
+    "\"SecretAccessKey\": \"SecretAccessKey321\", \"SessionToken\":\"TokenSuccess\", "
     "\"Expiration\":\"2020-02-25T06:03:31Z\"}");
 #else
 AWS_STATIC_STRING_FROM_LITERAL(
     s_test_command,
     "echo '{\"Version\": 1, \"AccessKeyId\": \"AccessKey123\", "
-    "\"SecretAccessKey\": \"SecretAccessKey321\", \"Token\":\"TokenSuccess\", "
+    "\"SecretAccessKey\": \"SecretAccessKey321\", \"SessionToken\":\"TokenSuccess\", "
     "\"Expiration\":\"2020-02-25T06:03:31Z\"}'");
 #endif
 


### PR DESCRIPTION
*Description of changes:*
This is a bug as according to [documentation](https://docs.aws.amazon.com/sdkref/latest/guide/feature-process-credentials.html) it should be `SessionToken`. Even our own [doc comments](https://github.com/awslabs/aws-c-auth/blob/main/include/aws/auth/credentials.h#L466) states `SessionToken`. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
