### PR TITLE
treat empty environment variable as unset

### DIFF
--- a/source/credentials_provider_environment.c
+++ b/source/credentials_provider_environment.c
@@ -30,7 +30,7 @@ static int s_credentials_provider_environment_get_credentials_async(
     aws_get_environment_value(allocator, s_secret_access_key_env_var, &secret_access_key);
     aws_get_environment_value(allocator, s_session_token_env_var, &session_token);
 
-    if (access_key_id != NULL && secret_access_key != NULL) {
+    if (access_key_id != NULL && access_key_id->len && secret_access_key != NULL && secret_access_key->len) {
         credentials =
             aws_credentials_new_from_string(allocator, access_key_id, secret_access_key, session_token, UINT64_MAX);
         if (credentials == NULL) {

--- a/source/credentials_provider_environment.c
+++ b/source/credentials_provider_environment.c
@@ -30,7 +30,7 @@ static int s_credentials_provider_environment_get_credentials_async(
     aws_get_environment_value(allocator, s_secret_access_key_env_var, &secret_access_key);
     aws_get_environment_value(allocator, s_session_token_env_var, &session_token);
 
-    if (access_key_id != NULL && access_key_id->len && secret_access_key != NULL && secret_access_key->len) {
+    if (access_key_id != NULL && access_key_id->len > 0 && secret_access_key != NULL && secret_access_key->len > 0) {
         credentials =
             aws_credentials_new_from_string(allocator, access_key_id, secret_access_key, session_token, UINT64_MAX);
         if (credentials == NULL) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -11,6 +11,7 @@ add_test_case(anonymous_credentials_create_destroy_test)
 add_test_case(static_credentials_provider_basic_test)
 add_test_case(anonymous_credentials_provider_basic_test)
 add_test_case(environment_credentials_provider_basic_test)
+add_test_case(environment_credentials_provider_empty_env_test)
 add_test_case(environment_credentials_provider_negative_test)
 add_test_case(cached_credentials_provider_elapsed_test)
 add_test_case(cached_credentials_provider_expired_test)
@@ -38,6 +39,7 @@ add_test_case(credentials_provider_imds_insecure_then_secure_success)
 add_test_case(credentials_provider_imds_success_multi_part_role_name)
 add_test_case(credentials_provider_imds_success_multi_part_doc)
 add_test_case(credentials_provider_imds_real_new_destroy)
+
 if(AWS_BUILDING_ON_EC2)
     add_test_case(credentials_provider_imds_real_success)
 endif()
@@ -50,6 +52,7 @@ add_test_case(credentials_provider_ecs_basic_success)
 add_test_case(credentials_provider_ecs_no_auth_token_success)
 add_test_case(credentials_provider_ecs_success_multi_part_doc)
 add_test_case(credentials_provider_ecs_real_new_destroy)
+
 if(AWS_BUILDING_ON_ECS)
     add_test_case(credentials_provider_ecs_real_success)
 endif()
@@ -100,7 +103,8 @@ add_net_test_case(credentials_provider_cognito_failure_request)
 add_net_test_case(credentials_provider_cognito_failure_bad_document)
 add_net_test_case(credentials_provider_cognito_success)
 add_net_test_case(credentials_provider_cognito_success_after_retry)
-if (AWS_HAS_CI_ENVIRONMENT)
+
+if(AWS_HAS_CI_ENVIRONMENT)
     add_net_test_case(credentials_provider_cognito_success_unauthenticated)
 endif()
 
@@ -272,10 +276,9 @@ set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
 generate_test_driver(${TEST_BINARY_NAME})
 
 # sigv4 test suite files
-
 add_custom_command(TARGET ${TEST_BINARY_NAME} PRE_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_SOURCE_DIR}/aws-signing-test-suite $<TARGET_FILE_DIR:${TEST_BINARY_NAME}>)
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/aws-signing-test-suite $<TARGET_FILE_DIR:${TEST_BINARY_NAME}>)
 
 file(GLOB FUZZ_TESTS "fuzz/*.c")
 aws_add_fuzz_tests("${FUZZ_TESTS}" "" "${CMAKE_CURRENT_SOURCE_DIR}/fuzz/corpus")

--- a/tests/credentials_tests.c
+++ b/tests/credentials_tests.c
@@ -250,6 +250,39 @@ static int s_environment_credentials_provider_basic_test(struct aws_allocator *a
 
 AWS_TEST_CASE(environment_credentials_provider_basic_test, s_environment_credentials_provider_basic_test);
 
+static int s_environment_credentials_provider_empty_env_test(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    s_aws_credentials_shutdown_checker_init();
+    struct aws_string *empty = aws_string_new_from_c_str(allocator, "");
+
+    aws_set_environment_value(s_access_key_id_env_var, empty);
+    aws_set_environment_value(s_secret_access_key_env_var, empty);
+    aws_set_environment_value(s_session_token_env_var, empty);
+
+    struct aws_credentials_provider_environment_options options = {
+        .shutdown_options =
+            {
+                .shutdown_callback = s_on_shutdown_complete,
+                .shutdown_user_data = NULL,
+            },
+    };
+
+    struct aws_credentials_provider *provider = aws_credentials_provider_new_environment(allocator, &options);
+    /* Instead of getting an empty credentials, should just fail to fetch credentials */
+    ASSERT_TRUE(s_do_basic_provider_test(provider, 1, NULL, NULL, NULL) == AWS_OP_SUCCESS);
+
+    aws_credentials_provider_release(provider);
+
+    s_aws_wait_for_provider_shutdown_callback();
+    aws_string_destroy(empty);
+    s_aws_credentials_shutdown_checker_clean_up();
+
+    return 0;
+}
+
+AWS_TEST_CASE(environment_credentials_provider_empty_env_test, s_environment_credentials_provider_empty_env_test);
+
 static int s_do_environment_credentials_provider_failure(struct aws_allocator *allocator) {
     s_aws_credentials_shutdown_checker_init();
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Keep it consistent with the behavior from aws cli.
- CLI will ignore the empty environment variables for `AWS_SECRET_ACCESS_KEY` and `AWS_ACCESS_KEY_ID`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
