### PR TITLE
Adapt to XML API changes

### DIFF
--- a/source/credentials_provider_sts.c
+++ b/source/credentials_provider_sts.c
@@ -254,7 +254,7 @@ static int s_sts_xml_on_Credentials_child(struct aws_xml_node *node, void *user_
         provider_user_data->session_token = aws_string_new_from_cursor(provider_user_data->allocator, &credential_data);
     }
 
-    return true;
+    return AWS_OP_SUCCESS;
 }
 
 static void s_start_make_request(

--- a/source/credentials_provider_sts.c
+++ b/source/credentials_provider_sts.c
@@ -356,6 +356,8 @@ static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_co
                 "(id=%p): credentials parsing failed with error %s",
                 (void *)provider_user_data->credentials,
                 aws_error_debug_str(provider_user_data->error_code));
+
+            provider_user_data->error_code = AWS_AUTH_CREDENTIALS_PROVIDER_STS_SOURCE_FAILURE;
             goto finish;
         }
 

--- a/source/credentials_provider_sts.c
+++ b/source/credentials_provider_sts.c
@@ -36,9 +36,9 @@
 #    pragma warning(disable : 4232)
 #endif
 
-static int s_sts_xml_on_AssumeRoleResponse_child(struct aws_xml_node *, bool *, void *);
-static int s_sts_xml_on_AssumeRoleResult_child(struct aws_xml_node *, bool *, void *);
-static int s_sts_xml_on_Credentials_child(struct aws_xml_node *, bool *, void *);
+static int s_sts_xml_on_AssumeRoleResponse_child(struct aws_xml_node *, void *);
+static int s_sts_xml_on_AssumeRoleResult_child(struct aws_xml_node *, void *);
+static int s_sts_xml_on_Credentials_child(struct aws_xml_node *, void *);
 
 static struct aws_http_header s_host_header = {
     .name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("host"),
@@ -198,8 +198,7 @@ static int s_on_incoming_body_fn(struct aws_http_stream *stream, const struct aw
       </AssumeRoleResult>
 </AssumeRoleResponse>
  */
-static int s_sts_xml_on_root(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
-    (void)stop_parsing;
+static int s_sts_xml_on_root(struct aws_xml_node *node, void *user_data) {
     struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AssumeRoleResponse")) {
         return aws_xml_node_traverse(node, s_sts_xml_on_AssumeRoleResponse_child, user_data);
@@ -207,8 +206,7 @@ static int s_sts_xml_on_root(struct aws_xml_node *node, bool *stop_parsing, void
     return AWS_OP_SUCCESS;
 }
 
-static int s_sts_xml_on_AssumeRoleResponse_child(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
-    (void)stop_parsing;
+static int s_sts_xml_on_AssumeRoleResponse_child(struct aws_xml_node *node, void *user_data) {
     struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AssumeRoleResult")) {
         return aws_xml_node_traverse(node, s_sts_xml_on_AssumeRoleResult_child, user_data);
@@ -216,8 +214,7 @@ static int s_sts_xml_on_AssumeRoleResponse_child(struct aws_xml_node *node, bool
     return AWS_OP_SUCCESS;
 }
 
-static int s_sts_xml_on_AssumeRoleResult_child(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
-    (void)stop_parsing;
+static int s_sts_xml_on_AssumeRoleResult_child(struct aws_xml_node *node, void *user_data) {
     struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "Credentials")) {
         return aws_xml_node_traverse(node, s_sts_xml_on_Credentials_child, user_data);
@@ -225,8 +222,7 @@ static int s_sts_xml_on_AssumeRoleResult_child(struct aws_xml_node *node, bool *
     return AWS_OP_SUCCESS;
 }
 
-static int s_sts_xml_on_Credentials_child(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
-    (void)stop_parsing;
+static int s_sts_xml_on_Credentials_child(struct aws_xml_node *node, void *user_data) {
     struct sts_creds_provider_user_data *provider_user_data = user_data;
     struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     struct aws_byte_cursor credential_data;

--- a/source/credentials_provider_sts.c
+++ b/source/credentials_provider_sts.c
@@ -36,6 +36,10 @@
 #    pragma warning(disable : 4232)
 #endif
 
+static int s_sts_xml_on_AssumeRoleResponse_child(struct aws_xml_node *, bool *, void *);
+static int s_sts_xml_on_AssumeRoleResult_child(struct aws_xml_node *, bool *, void *);
+static int s_sts_xml_on_Credentials_child(struct aws_xml_node *, bool *, void *);
+
 static struct aws_http_header s_host_header = {
     .name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("host"),
     .value = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("sts.amazonaws.com"),
@@ -50,12 +54,6 @@ static struct aws_byte_cursor s_content_length = AWS_BYTE_CUR_INIT_FROM_STRING_L
 static struct aws_byte_cursor s_path = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("/");
 static struct aws_byte_cursor s_signing_region = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("us-east-1");
 static struct aws_byte_cursor s_service_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("sts");
-static struct aws_byte_cursor s_assume_role_root_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("AssumeRoleResponse");
-static struct aws_byte_cursor s_assume_role_result_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("AssumeRoleResult");
-static struct aws_byte_cursor s_assume_role_credentials_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("Credentials");
-static struct aws_byte_cursor s_assume_role_session_token_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("SessionToken");
-static struct aws_byte_cursor s_assume_role_secret_key_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("SecretAccessKey");
-static struct aws_byte_cursor s_assume_role_access_key_id_name = AWS_BYTE_CUR_INIT_FROM_STRING_LITERAL("AccessKeyId");
 static const int s_max_retries = 8;
 
 const uint16_t aws_sts_assume_role_default_duration_secs = 900;
@@ -190,7 +188,7 @@ static int s_on_incoming_body_fn(struct aws_http_stream *stream, const struct aw
      <AssumeRoleResult>
           <Credentials>
              <AccessKeyId>accessKeyId</AccessKeyId>
-             <SecretKey>secretKey</SecretKey>
+             <SecretAccessKey>secretKey</SecretAccessKey>
              <SessionToken>sessionToken</SessionToken>
           </Credentials>
          <AssumedRoleUser>
@@ -200,53 +198,64 @@ static int s_on_incoming_body_fn(struct aws_http_stream *stream, const struct aw
       </AssumeRoleResult>
 </AssumeRoleResponse>
  */
-static bool s_on_node_encountered_fn(struct aws_xml_parser *parser, struct aws_xml_node *node, void *user_data) {
-
-    struct aws_byte_cursor node_name;
-    AWS_ZERO_STRUCT(node_name);
-
-    if (aws_xml_node_get_name(node, &node_name)) {
-        AWS_LOGF_ERROR(
-            AWS_LS_AUTH_CREDENTIALS_PROVIDER,
-            "(id=%p): While parsing credentials xml response for sts credentials provider, could not get xml node name "
-            "for function s_on_node_encountered_fn.",
-            user_data);
-        return false;
+static int s_sts_xml_on_root(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
+    (void)stop_parsing;
+    struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
+    if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AssumeRoleResponse")) {
+        return aws_xml_node_traverse(node, s_sts_xml_on_AssumeRoleResponse_child, user_data);
     }
+    return AWS_OP_SUCCESS;
+}
 
-    if (aws_byte_cursor_eq_ignore_case(&node_name, &s_assume_role_root_name) ||
-        aws_byte_cursor_eq_ignore_case(&node_name, &s_assume_role_result_name) ||
-        aws_byte_cursor_eq_ignore_case(&node_name, &s_assume_role_credentials_name)) {
-        return aws_xml_node_traverse(parser, node, s_on_node_encountered_fn, user_data);
+static int s_sts_xml_on_AssumeRoleResponse_child(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
+    (void)stop_parsing;
+    struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
+    if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AssumeRoleResult")) {
+        return aws_xml_node_traverse(node, s_sts_xml_on_AssumeRoleResult_child, user_data);
     }
+    return AWS_OP_SUCCESS;
+}
 
+static int s_sts_xml_on_AssumeRoleResult_child(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
+    (void)stop_parsing;
+    struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
+    if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "Credentials")) {
+        return aws_xml_node_traverse(node, s_sts_xml_on_Credentials_child, user_data);
+    }
+    return AWS_OP_SUCCESS;
+}
+
+static int s_sts_xml_on_Credentials_child(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
+    (void)stop_parsing;
     struct sts_creds_provider_user_data *provider_user_data = user_data;
+    struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     struct aws_byte_cursor credential_data;
     AWS_ZERO_STRUCT(credential_data);
-    if (aws_byte_cursor_eq_ignore_case(&node_name, &s_assume_role_access_key_id_name)) {
-        aws_xml_node_as_body(parser, node, &credential_data);
-        provider_user_data->access_key_id =
-            aws_string_new_from_array(provider_user_data->allocator, credential_data.ptr, credential_data.len);
-
-        if (provider_user_data->access_key_id) {
-            AWS_LOGF_DEBUG(
-                AWS_LS_AUTH_CREDENTIALS_PROVIDER,
-                "(id=%p): Read AccessKeyId %s",
-                (void *)provider_user_data->provider,
-                aws_string_c_str(provider_user_data->access_key_id));
+    if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AccessKeyId")) {
+        if (aws_xml_node_as_body(node, &credential_data)) {
+            return AWS_OP_ERR;
         }
+        provider_user_data->access_key_id = aws_string_new_from_cursor(provider_user_data->allocator, &credential_data);
+        AWS_LOGF_DEBUG(
+            AWS_LS_AUTH_CREDENTIALS_PROVIDER,
+            "(id=%p): Read AccessKeyId %s",
+            (void *)provider_user_data->provider,
+            aws_string_c_str(provider_user_data->access_key_id));
     }
 
-    if (aws_byte_cursor_eq_ignore_case(&node_name, &s_assume_role_secret_key_name)) {
-        aws_xml_node_as_body(parser, node, &credential_data);
+    if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "SecretAccessKey")) {
+        if (aws_xml_node_as_body(node, &credential_data)) {
+            return AWS_OP_ERR;
+        }
         provider_user_data->secret_access_key =
-            aws_string_new_from_array(provider_user_data->allocator, credential_data.ptr, credential_data.len);
+            aws_string_new_from_cursor(provider_user_data->allocator, &credential_data);
     }
 
-    if (aws_byte_cursor_eq_ignore_case(&node_name, &s_assume_role_session_token_name)) {
-        aws_xml_node_as_body(parser, node, &credential_data);
-        provider_user_data->session_token =
-            aws_string_new_from_array(provider_user_data->allocator, credential_data.ptr, credential_data.len);
+    if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "SessionToken")) {
+        if (aws_xml_node_as_body(node, &credential_data)) {
+            return AWS_OP_ERR;
+        }
+        provider_user_data->session_token = aws_string_new_from_cursor(provider_user_data->allocator, &credential_data);
     }
 
     return true;
@@ -277,7 +286,6 @@ static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_co
     int http_response_code = 0;
     struct sts_creds_provider_user_data *provider_user_data = user_data;
     struct aws_credentials_provider_sts_impl *provider_impl = provider_user_data->provider->impl;
-    struct aws_xml_parser *xml_parser = NULL;
 
     provider_user_data->error_code = error_code;
 
@@ -333,16 +341,6 @@ static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_co
             goto finish;
         }
 
-        struct aws_xml_parser_options options;
-        AWS_ZERO_STRUCT(options);
-        options.doc = aws_byte_cursor_from_buf(&provider_user_data->output_buf);
-
-        xml_parser = aws_xml_parser_new(provider_user_data->provider->allocator, &options);
-
-        if (xml_parser == NULL) {
-            goto finish;
-        }
-
         uint64_t now = UINT64_MAX;
         if (provider_impl->system_clock_fn(&now) != AWS_OP_SUCCESS) {
             goto finish;
@@ -350,7 +348,12 @@ static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_co
 
         uint64_t now_seconds = aws_timestamp_convert(now, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_SECS, NULL);
 
-        if (aws_xml_parser_parse(xml_parser, s_on_node_encountered_fn, provider_user_data)) {
+        struct aws_xml_parser_options options = {
+            .doc = aws_byte_cursor_from_buf(&provider_user_data->output_buf),
+            .on_root_encountered = s_sts_xml_on_root,
+            .user_data = provider_user_data,
+        };
+        if (aws_xml_parse(provider_user_data->provider->allocator, &options)) {
             provider_user_data->error_code = aws_last_error();
             AWS_LOGF_ERROR(
                 AWS_LS_AUTH_CREDENTIALS_PROVIDER,
@@ -369,7 +372,10 @@ static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_co
                 provider_user_data->secret_access_key,
                 provider_user_data->session_token,
                 now_seconds + provider_impl->duration_seconds);
-        } else {
+        }
+
+        if (provider_user_data->credentials == NULL) {
+            provider_user_data->error_code = AWS_AUTH_CREDENTIALS_PROVIDER_STS_SOURCE_FAILURE;
             AWS_LOGF_ERROR(
                 AWS_LS_AUTH_CREDENTIALS_PROVIDER,
                 "(id=%p): credentials document was corrupted, treating as an error.",
@@ -378,11 +384,6 @@ static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_co
     }
 
 finish:
-
-    if (xml_parser != NULL) {
-        aws_xml_parser_destroy(xml_parser);
-        xml_parser = NULL;
-    }
 
     s_clean_up_user_data(provider_user_data);
 }

--- a/source/credentials_provider_sts_web_identity.c
+++ b/source/credentials_provider_sts_web_identity.c
@@ -37,10 +37,10 @@
 #define STS_WEB_IDENTITY_MAX_ATTEMPTS 3
 
 static void s_on_connection_manager_shutdown(void *user_data);
-static int s_stswebid_error_xml_on_Error_child(struct aws_xml_node *, bool *, void *);
-static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResponse_child(struct aws_xml_node *, bool *, void *);
-static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResult_child(struct aws_xml_node *, bool *, void *);
-static int s_stswebid_200_xml_on_Credentials_child(struct aws_xml_node *, bool *, void *);
+static int s_stswebid_error_xml_on_Error_child(struct aws_xml_node *, void *);
+static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResponse_child(struct aws_xml_node *, void *);
+static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResult_child(struct aws_xml_node *, void *);
+static int s_stswebid_200_xml_on_Credentials_child(struct aws_xml_node *, void *);
 
 struct aws_credentials_provider_sts_web_identity_impl {
     struct aws_http_connection_manager *connection_manager;
@@ -191,9 +191,7 @@ Error Response looks like:
 </Error>
 */
 
-static int s_stswebid_error_xml_on_root(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
-    (void)stop_parsing;
-
+static int s_stswebid_error_xml_on_root(struct aws_xml_node *node, void *user_data) {
     struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "Error")) {
         return aws_xml_node_traverse(node, s_stswebid_error_xml_on_Error_child, user_data);
@@ -202,8 +200,7 @@ static int s_stswebid_error_xml_on_root(struct aws_xml_node *node, bool *stop_pa
     return AWS_OP_SUCCESS;
 }
 
-static int s_stswebid_error_xml_on_Error_child(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
-    (void)stop_parsing;
+static int s_stswebid_error_xml_on_Error_child(struct aws_xml_node *node, void *user_data) {
     bool *get_retryable_error = user_data;
 
     struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
@@ -243,8 +240,7 @@ static bool s_parse_retryable_error_from_response(struct aws_allocator *allocato
     return get_retryable_error;
 }
 
-static int s_stswebid_200_xml_on_root(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
-    (void)stop_parsing;
+static int s_stswebid_200_xml_on_root(struct aws_xml_node *node, void *user_data) {
     struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AssumeRoleWithWebIdentityResponse")) {
         return aws_xml_node_traverse(node, s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResponse_child, user_data);
@@ -254,10 +250,9 @@ static int s_stswebid_200_xml_on_root(struct aws_xml_node *node, bool *stop_pars
 
 static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResponse_child(
     struct aws_xml_node *node,
-    bool *stop_parsing,
+
     void *user_data) {
 
-    (void)stop_parsing;
     struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AssumeRoleWithWebIdentityResult")) {
         return aws_xml_node_traverse(node, s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResult_child, user_data);
@@ -267,10 +262,9 @@ static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResponse_child(
 
 static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResult_child(
     struct aws_xml_node *node,
-    bool *stop_parsing,
+
     void *user_data) {
 
-    (void)stop_parsing;
     struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "Credentials")) {
         return aws_xml_node_traverse(node, s_stswebid_200_xml_on_Credentials_child, user_data);
@@ -278,8 +272,7 @@ static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResult_child(
     return AWS_OP_SUCCESS;
 }
 
-static int s_stswebid_200_xml_on_Credentials_child(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
-    (void)stop_parsing;
+static int s_stswebid_200_xml_on_Credentials_child(struct aws_xml_node *node, void *user_data) {
     struct sts_web_identity_user_data *query_user_data = user_data;
 
     struct aws_byte_cursor node_name = aws_xml_node_get_name(node);

--- a/source/credentials_provider_sts_web_identity.c
+++ b/source/credentials_provider_sts_web_identity.c
@@ -37,6 +37,10 @@
 #define STS_WEB_IDENTITY_MAX_ATTEMPTS 3
 
 static void s_on_connection_manager_shutdown(void *user_data);
+static int s_stswebid_error_xml_on_Error_child(struct aws_xml_node *, bool *, void *);
+static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResponse_child(struct aws_xml_node *, bool *, void *);
+static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResult_child(struct aws_xml_node *, bool *, void *);
+static int s_stswebid_200_xml_on_Credentials_child(struct aws_xml_node *, bool *, void *);
 
 struct aws_credentials_provider_sts_web_identity_impl {
     struct aws_http_connection_manager *connection_manager;
@@ -187,128 +191,145 @@ Error Response looks like:
 </Error>
 */
 
-static bool s_on_error_node_encountered_fn(struct aws_xml_parser *parser, struct aws_xml_node *node, void *user_data) {
+static int s_stswebid_error_xml_on_root(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
+    (void)stop_parsing;
 
-    struct aws_byte_cursor node_name;
-    AWS_ZERO_STRUCT(node_name);
-
-    if (aws_xml_node_get_name(node, &node_name)) {
-        AWS_LOGF_ERROR(
-            AWS_LS_AUTH_CREDENTIALS_PROVIDER,
-            "(id=%p): While parsing xml error response for sts web identity credentials provider, could not get xml "
-            "node name for function s_on_error_node_encountered_fn.",
-            user_data);
-        return false;
-    }
-
+    struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "Error")) {
-        return aws_xml_node_traverse(parser, node, s_on_error_node_encountered_fn, user_data);
+        return aws_xml_node_traverse(node, s_stswebid_error_xml_on_Error_child, user_data);
     }
 
-    bool *get_retryable_error = user_data;
-    struct aws_byte_cursor data_cursor;
-    AWS_ZERO_STRUCT(data_cursor);
+    return AWS_OP_SUCCESS;
+}
 
+static int s_stswebid_error_xml_on_Error_child(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
+    (void)stop_parsing;
+    bool *get_retryable_error = user_data;
+
+    struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "Code")) {
-        aws_xml_node_as_body(parser, node, &data_cursor);
+
+        struct aws_byte_cursor data_cursor = {0};
+        if (aws_xml_node_as_body(node, &data_cursor)) {
+            return AWS_OP_ERR;
+        }
+
         if (aws_byte_cursor_eq_c_str_ignore_case(&data_cursor, "IDPCommunicationError") ||
             aws_byte_cursor_eq_c_str_ignore_case(&data_cursor, "InvalidIdentityToken")) {
             *get_retryable_error = true;
         }
     }
 
-    return true;
+    return AWS_OP_SUCCESS;
 }
 
 static bool s_parse_retryable_error_from_response(struct aws_allocator *allocator, struct aws_byte_buf *response) {
 
-    struct aws_xml_parser_options options;
-    AWS_ZERO_STRUCT(options);
-    options.doc = aws_byte_cursor_from_buf(response);
-
-    struct aws_xml_parser *xml_parser = aws_xml_parser_new(allocator, &options);
-
-    if (xml_parser == NULL) {
-        AWS_LOGF_ERROR(
-            AWS_LS_AUTH_CREDENTIALS_PROVIDER,
-            "Failed to init xml parser for sts web identity credentials provider to parse error information.");
-        return false;
-    }
     bool get_retryable_error = false;
-    if (aws_xml_parser_parse(xml_parser, s_on_error_node_encountered_fn, &get_retryable_error)) {
+    struct aws_xml_parser_options options = {
+        .doc = aws_byte_cursor_from_buf(response),
+        .on_root_encountered = s_stswebid_error_xml_on_root,
+        .user_data = &get_retryable_error,
+    };
+
+    if (aws_xml_parse(allocator, &options)) {
         AWS_LOGF_ERROR(
             AWS_LS_AUTH_CREDENTIALS_PROVIDER,
             "Failed to parse xml error response for sts web identity with error %s",
             aws_error_str(aws_last_error()));
-        aws_xml_parser_destroy(xml_parser);
         return false;
     }
 
-    aws_xml_parser_destroy(xml_parser);
     return get_retryable_error;
 }
 
-static bool s_on_creds_node_encountered_fn(struct aws_xml_parser *parser, struct aws_xml_node *node, void *user_data) {
-
-    struct aws_byte_cursor node_name;
-    AWS_ZERO_STRUCT(node_name);
-
-    if (aws_xml_node_get_name(node, &node_name)) {
-        AWS_LOGF_ERROR(
-            AWS_LS_AUTH_CREDENTIALS_PROVIDER,
-            "(id=%p): While parsing credentials xml response for sts web identity credentials provider, could not get "
-            "xml node name for function s_on_creds_node_encountered_fn.",
-            user_data);
-        return false;
+static int s_stswebid_200_xml_on_root(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
+    (void)stop_parsing;
+    struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
+    if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AssumeRoleWithWebIdentityResponse")) {
+        return aws_xml_node_traverse(node, s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResponse_child, user_data);
     }
+    return AWS_OP_SUCCESS;
+}
 
-    if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AssumeRoleWithWebIdentityResponse") ||
-        aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AssumeRoleWithWebIdentityResult") ||
-        aws_byte_cursor_eq_c_str_ignore_case(&node_name, "Credentials")) {
-        return aws_xml_node_traverse(parser, node, s_on_creds_node_encountered_fn, user_data);
+static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResponse_child(
+    struct aws_xml_node *node,
+    bool *stop_parsing,
+    void *user_data) {
+
+    (void)stop_parsing;
+    struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
+    if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AssumeRoleWithWebIdentityResult")) {
+        return aws_xml_node_traverse(node, s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResult_child, user_data);
     }
+    return AWS_OP_SUCCESS;
+}
 
+static int s_stswebid_200_xml_on_AssumeRoleWithWebIdentityResult_child(
+    struct aws_xml_node *node,
+    bool *stop_parsing,
+    void *user_data) {
+
+    (void)stop_parsing;
+    struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
+    if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "Credentials")) {
+        return aws_xml_node_traverse(node, s_stswebid_200_xml_on_Credentials_child, user_data);
+    }
+    return AWS_OP_SUCCESS;
+}
+
+static int s_stswebid_200_xml_on_Credentials_child(struct aws_xml_node *node, bool *stop_parsing, void *user_data) {
+    (void)stop_parsing;
     struct sts_web_identity_user_data *query_user_data = user_data;
+
+    struct aws_byte_cursor node_name = aws_xml_node_get_name(node);
     struct aws_byte_cursor credential_data;
     AWS_ZERO_STRUCT(credential_data);
+
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "AccessKeyId")) {
-        aws_xml_node_as_body(parser, node, &credential_data);
-        query_user_data->access_key_id =
-            aws_string_new_from_array(query_user_data->allocator, credential_data.ptr, credential_data.len);
+        if (aws_xml_node_as_body(node, &credential_data)) {
+            return AWS_OP_ERR;
+        }
+        query_user_data->access_key_id = aws_string_new_from_cursor(query_user_data->allocator, &credential_data);
     }
 
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "SecretAccessKey")) {
-        aws_xml_node_as_body(parser, node, &credential_data);
-        query_user_data->secret_access_key =
-            aws_string_new_from_array(query_user_data->allocator, credential_data.ptr, credential_data.len);
+        if (aws_xml_node_as_body(node, &credential_data)) {
+            return AWS_OP_ERR;
+        }
+        query_user_data->secret_access_key = aws_string_new_from_cursor(query_user_data->allocator, &credential_data);
     }
 
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "SessionToken")) {
-        aws_xml_node_as_body(parser, node, &credential_data);
-        query_user_data->session_token =
-            aws_string_new_from_array(query_user_data->allocator, credential_data.ptr, credential_data.len);
+        if (aws_xml_node_as_body(node, &credential_data)) {
+            return AWS_OP_ERR;
+        }
+        query_user_data->session_token = aws_string_new_from_cursor(query_user_data->allocator, &credential_data);
     }
 
     /* As long as we parsed an usable expiration, use it, otherwise use
      * the existing one: now + 900s, initialized before parsing.
      */
     if (aws_byte_cursor_eq_c_str_ignore_case(&node_name, "Expiration")) {
-        aws_xml_node_as_body(parser, node, &credential_data);
+        if (aws_xml_node_as_body(node, &credential_data)) {
+            return AWS_OP_ERR;
+        }
         if (credential_data.len != 0) {
             struct aws_date_time expiration;
             if (aws_date_time_init_from_str_cursor(&expiration, &credential_data, AWS_DATE_FORMAT_ISO_8601) ==
                 AWS_OP_SUCCESS) {
                 query_user_data->expiration_timepoint_in_seconds = (uint64_t)aws_date_time_as_epoch_secs(&expiration);
             } else {
-                query_user_data->error_code = aws_last_error();
                 AWS_LOGF_ERROR(
                     AWS_LS_AUTH_CREDENTIALS_PROVIDER,
                     "Failed to parse time string from sts web identity xml response: %s",
-                    aws_error_str(query_user_data->error_code));
+                    aws_error_str(aws_last_error()));
+                return AWS_OP_ERR;
             }
         }
     }
-    return true;
+
+    return AWS_OP_SUCCESS;
 }
 
 static struct aws_credentials *s_parse_credentials_from_response(
@@ -321,18 +342,6 @@ static struct aws_credentials *s_parse_credentials_from_response(
 
     struct aws_credentials *credentials = NULL;
 
-    struct aws_xml_parser_options options;
-    AWS_ZERO_STRUCT(options);
-    options.doc = aws_byte_cursor_from_buf(response);
-
-    struct aws_xml_parser *xml_parser = aws_xml_parser_new(query_user_data->allocator, &options);
-
-    if (xml_parser == NULL) {
-        AWS_LOGF_ERROR(
-            AWS_LS_AUTH_CREDENTIALS_PROVIDER,
-            "Failed to init xml parser for sts web identity credentials provider to parse error information.");
-        return NULL;
-    }
     uint64_t now = UINT64_MAX;
     if (aws_sys_clock_get_ticks(&now) != AWS_OP_SUCCESS) {
         AWS_LOGF_ERROR(
@@ -343,7 +352,12 @@ static struct aws_credentials *s_parse_credentials_from_response(
     uint64_t now_seconds = aws_timestamp_convert(now, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_SECS, NULL);
     query_user_data->expiration_timepoint_in_seconds = now_seconds + STS_WEB_IDENTITY_CREDS_DEFAULT_DURATION_SECONDS;
 
-    if (aws_xml_parser_parse(xml_parser, s_on_creds_node_encountered_fn, query_user_data)) {
+    struct aws_xml_parser_options options = {
+        .doc = aws_byte_cursor_from_buf(response),
+        .on_root_encountered = s_stswebid_200_xml_on_root,
+        .user_data = query_user_data,
+    };
+    if (aws_xml_parse(query_user_data->allocator, &options)) {
         AWS_LOGF_ERROR(
             AWS_LS_AUTH_CREDENTIALS_PROVIDER,
             "Failed to parse xml response for sts web identity with error: %s",
@@ -352,6 +366,8 @@ static struct aws_credentials *s_parse_credentials_from_response(
     }
 
     if (!query_user_data->access_key_id || !query_user_data->secret_access_key) {
+        AWS_LOGF_ERROR(AWS_LS_AUTH_CREDENTIALS_PROVIDER, "STS web identity not found in XML response.");
+        aws_raise_error(AWS_AUTH_CREDENTIALS_PROVIDER_STS_WEB_IDENTITY_SOURCE_FAILURE);
         goto on_finish;
     }
 
@@ -366,11 +382,6 @@ on_finish:
 
     if (credentials == NULL) {
         query_user_data->error_code = aws_last_error();
-    }
-
-    if (xml_parser != NULL) {
-        aws_xml_parser_destroy(xml_parser);
-        xml_parser = NULL;
     }
 
     return credentials;


### PR DESCRIPTION
- Adapt to API changes from: https://github.com/awslabs/aws-c-common/pull/1043
- Break up node traversal functions, to ensure we're processing the correct XML elements.
    - Previously, the same callback would be used for all XML elements. This could cause error if an element with the same name occurred at different parts of the document tree.
- Improved error checking
    - Previously, many calls to `aws_xml_node_as_body()` weren't being checked for error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
