### PR TITLE
Minor CMakelists.txt cleanup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,13 +54,6 @@ if (WIN32)
         source_group("Header Files\\aws\\auth" FILES ${AWS_AUTH_HEADERS})
         source_group("Source Files" FILES ${AWS_AUTH_SRC})
     endif ()
-    set(PLATFORM_LIBS "")
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    set(PLATFORM_LIBS "")
-elseif (APPLE)
-    set(PLATFORM_LIBS "")
-elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
-    set(PLATFORM_LIBS "")
 endif()
 
 file(GLOB AUTH_HEADERS
@@ -96,7 +89,7 @@ aws_use_package(aws-c-sdkutils)
 aws_use_package(aws-c-cal)
 aws_use_package(aws-c-http)
 
-target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS} ${PLATFORM_LIBS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})
 
 aws_prepare_shared_lib_exports(${PROJECT_NAME})
 


### PR DESCRIPTION
Remove unused PLATFORM_LIBS variable. aws-c-auth picks up these dependencies transitively via aws-c-common. The presence of this variable was confusing to some users (see https://github.com/awslabs/aws-c-auth/pull/152)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
