### PR TITLE
aws_signable refcounts request

### DIFF
--- a/source/signable_http_request.c
+++ b/source/signable_http_request.c
@@ -76,6 +76,7 @@ static void s_aws_signable_http_request_destroy(struct aws_signable *signable) {
         return;
     }
 
+    aws_http_message_release(impl->request);
     aws_array_list_clean_up(&impl->headers);
     aws_mem_release(signable->allocator, signable);
 }
@@ -118,7 +119,7 @@ struct aws_signable *aws_signable_new_http_request(struct aws_allocator *allocat
         aws_array_list_push_back(&impl->headers, &property);
     }
 
-    impl->request = request;
+    impl->request = aws_http_message_acquire(request);
 
     return signable;
 

--- a/tests/sigv4_signing_tests.c
+++ b/tests/sigv4_signing_tests.c
@@ -1527,6 +1527,9 @@ static int s_do_header_skip_test(
     ASSERT_SUCCESS(s_parse_request(allocator, aws_byte_cursor_from_string(request_contents), &message, &body_stream));
     struct aws_signable *signable = aws_signable_new_http_request(allocator, message);
 
+    /* release reference to message early, to ensure signable keeps it alive */
+    aws_http_message_release(message);
+
     struct aws_signing_state_aws *signing_state = aws_signing_state_new(allocator, &config, signable, NULL, NULL);
     ASSERT_NOT_NULL(signing_state);
 
@@ -1539,7 +1542,6 @@ static int s_do_header_skip_test(
         signing_state->canonical_request.len);
 
     aws_input_stream_destroy(body_stream);
-    aws_http_message_release(message);
     aws_signing_state_destroy(signing_state);
     aws_credentials_release(credentials);
     aws_signable_destroy(signable);


### PR DESCRIPTION
Fix bug where `aws_signable_new_http_request()` was keeping a pointer to to the request, but wasn't refcounting it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
