### PR TITLE
Change `port` from uint16_t to uint32_t, to support VSOCK

### DIFF
--- a/include/aws/auth/credentials.h
+++ b/include/aws/auth/credentials.h
@@ -277,7 +277,7 @@ struct aws_credentials_provider_ecs_options {
     /*
      * Port to query credentials from.  If zero, 80/443 will be used based on whether or not tls is enabled.
      */
-    uint16_t port;
+    uint32_t port;
 };
 
 /**

--- a/tests/credentials_provider_ecs_tests.c
+++ b/tests/credentials_provider_ecs_tests.c
@@ -32,7 +32,7 @@ struct aws_mock_ecs_tester {
     struct aws_credentials *credentials;
     bool has_received_credentials_callback;
     bool has_received_shutdown_callback;
-    uint16_t selected_port;
+    uint32_t selected_port;
 
     int error_code;
 };


### PR DESCRIPTION
Issue: https://github.com/awslabs/aws-c-io/issues/576

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
