### PR TITLE
Fix error when tests run in parallel.

### DIFF
--- a/tests/credentials_provider_sso_tests.c
+++ b/tests/credentials_provider_sso_tests.c
@@ -326,9 +326,6 @@ static int s_credentials_provider_sso_connect_failure(struct aws_allocator *allo
 }
 AWS_TEST_CASE(credentials_provider_sso_connect_failure, s_credentials_provider_sso_connect_failure);
 
-AWS_STATIC_STRING_FROM_LITERAL(s_home_env_var, "HOME");
-AWS_STATIC_STRING_FROM_LITERAL(s_home_env_current_directory, ".");
-
 static int s_credentials_provider_sso_failure_token_missing(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
@@ -336,7 +333,8 @@ static int s_credentials_provider_sso_failure_token_missing(struct aws_allocator
     credentials_provider_http_mock_tester.is_request_successful = false;
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     s_aws_credentials_provider_sso_test_init_config_profile(allocator, s_sso_session_config_contents);
 
@@ -366,6 +364,8 @@ static int s_credentials_provider_sso_failure_token_missing(struct aws_allocator
     aws_credentials_provider_http_mock_wait_for_shutdown_callback();
 
     aws_credentials_provider_http_mock_tester_cleanup();
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
 
     return 0;
 }
@@ -383,7 +383,8 @@ static int s_credentials_provider_sso_failure_token_expired(struct aws_allocator
     credentials_provider_http_mock_tester.is_request_successful = false;
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -423,6 +424,8 @@ static int s_credentials_provider_sso_failure_token_expired(struct aws_allocator
     aws_credentials_provider_http_mock_wait_for_shutdown_callback();
 
     aws_credentials_provider_http_mock_tester_cleanup();
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     return 0;
 }
@@ -436,7 +439,8 @@ static int s_credentials_provider_sso_failure_token_empty(struct aws_allocator *
     credentials_provider_http_mock_tester.is_request_successful = false;
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -474,6 +478,8 @@ static int s_credentials_provider_sso_failure_token_empty(struct aws_allocator *
     aws_credentials_provider_http_mock_wait_for_shutdown_callback();
 
     aws_credentials_provider_http_mock_tester_cleanup();
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     return 0;
 }
@@ -487,7 +493,8 @@ static int s_credentials_provider_sso_request_failure(struct aws_allocator *allo
     credentials_provider_http_mock_tester.response_code = AWS_HTTP_STATUS_CODE_400_BAD_REQUEST;
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -526,6 +533,8 @@ static int s_credentials_provider_sso_request_failure(struct aws_allocator *allo
 
     aws_credentials_provider_http_mock_tester_cleanup();
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     return 0;
 }
@@ -538,7 +547,8 @@ static int s_credentials_provider_sso_bad_response(struct aws_allocator *allocat
     aws_credentials_provider_http_mock_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -581,6 +591,8 @@ static int s_credentials_provider_sso_bad_response(struct aws_allocator *allocat
 
     aws_credentials_provider_http_mock_tester_cleanup();
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     return 0;
 }
@@ -593,7 +605,8 @@ static int s_credentials_provider_sso_retryable_error(struct aws_allocator *allo
     credentials_provider_http_mock_tester.response_code = AWS_HTTP_STATUS_CODE_500_INTERNAL_SERVER_ERROR;
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -636,6 +649,8 @@ static int s_credentials_provider_sso_retryable_error(struct aws_allocator *allo
 
     aws_credentials_provider_http_mock_tester_cleanup();
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     return 0;
 }
@@ -647,7 +662,8 @@ static int s_credentials_provider_sso_basic_success(struct aws_allocator *alloca
     aws_credentials_provider_http_mock_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -691,6 +707,8 @@ static int s_credentials_provider_sso_basic_success(struct aws_allocator *alloca
 
     aws_credentials_provider_http_mock_tester_cleanup();
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     return 0;
 }
@@ -702,7 +720,8 @@ static int s_credentials_provider_sso_basic_success_cached_config_file(struct aw
     aws_credentials_provider_http_mock_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -751,6 +770,8 @@ static int s_credentials_provider_sso_basic_success_cached_config_file(struct aw
 
     aws_credentials_provider_http_mock_tester_cleanup();
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     aws_profile_collection_release(config_collection);
 
@@ -766,7 +787,8 @@ static int s_credentials_provider_sso_basic_success_profile(struct aws_allocator
     aws_credentials_provider_http_mock_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_profile_start_url);
@@ -810,6 +832,8 @@ static int s_credentials_provider_sso_basic_success_profile(struct aws_allocator
 
     aws_credentials_provider_http_mock_tester_cleanup();
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     return 0;
 }
@@ -823,7 +847,8 @@ static int s_credentials_provider_sso_basic_success_profile_cached_config_file(
     aws_credentials_provider_http_mock_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_profile_start_url);
@@ -870,6 +895,8 @@ static int s_credentials_provider_sso_basic_success_profile_cached_config_file(
     aws_credentials_provider_http_mock_wait_for_shutdown_callback();
     aws_credentials_provider_http_mock_tester_cleanup();
     aws_profile_collection_release(config_collection);
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
 
     return 0;
@@ -885,7 +912,8 @@ static int s_credentials_provider_sso_basic_success_after_failure(struct aws_all
     credentials_provider_http_mock_tester.failure_count = 2;
     credentials_provider_http_mock_tester.failure_response_code = AWS_HTTP_STATUS_CODE_500_INTERNAL_SERVER_ERROR;
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -929,6 +957,8 @@ static int s_credentials_provider_sso_basic_success_after_failure(struct aws_all
 
     aws_credentials_provider_http_mock_tester_cleanup();
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     return 0;
 }

--- a/tests/credentials_provider_utils.h
+++ b/tests/credentials_provider_utils.h
@@ -102,6 +102,11 @@ struct aws_credentials_provider *aws_credentials_provider_new_null(
 int aws_create_directory_components(struct aws_allocator *allocator, const struct aws_string *path);
 
 /**
+ * Create a new directory (under current working dir) and set $HOME env variable.
+ */
+int aws_create_random_home_directory(struct aws_allocator *allocator, struct aws_string **out_path);
+
+/**
  * Mocked HTTP connection manager for tests
  */
 struct aws_credentials_provider_http_mock_tester {

--- a/tests/token_provider_sso_tests.c
+++ b/tests/token_provider_sso_tests.c
@@ -9,6 +9,7 @@
 #include <aws/auth/private/sso_token_utils.h>
 #include <aws/common/clock.h>
 #include <aws/common/environment.h>
+#include <aws/common/file.h>
 #include <aws/io/channel_bootstrap.h>
 #include <aws/io/event_loop.h>
 #include <aws/io/tls_channel_handler.h>
@@ -315,8 +316,6 @@ AWS_STATIC_STRING_FROM_LITERAL(
     "{\"accessToken\": \"ValidAccessToken\",\"expiresAt\": \"2015-03-12T05:35:19Z\"}");
 AWS_STATIC_STRING_FROM_LITERAL(s_invalid_config, "invalid config");
 
-AWS_STATIC_STRING_FROM_LITERAL(s_home_env_var, "HOME");
-AWS_STATIC_STRING_FROM_LITERAL(s_home_env_current_directory, ".");
 AWS_STATIC_STRING_FROM_LITERAL(s_good_token, "ValidAccessToken");
 static uint64_t s_token_expiration_s = 1426138519;
 static int s_sso_token_provider_sso_session_basic_success(struct aws_allocator *allocator, void *ctx) {
@@ -324,7 +323,8 @@ static int s_sso_token_provider_sso_session_basic_success(struct aws_allocator *
     s_aws_mock_token_provider_sso_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -358,6 +358,8 @@ static int s_sso_token_provider_sso_session_basic_success(struct aws_allocator *
     aws_get_credentials_test_callback_result_clean_up(&callback_results);
     aws_credentials_provider_release(provider);
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     aws_string_destroy(config_file_str);
     s_aws_mock_token_provider_sso_tester_cleanup();
@@ -371,7 +373,8 @@ static int s_sso_token_provider_sso_session_config_file_cached(struct aws_alloca
     s_aws_mock_token_provider_sso_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -411,6 +414,8 @@ static int s_sso_token_provider_sso_session_config_file_cached(struct aws_alloca
     aws_get_credentials_test_callback_result_clean_up(&callback_results);
     aws_credentials_provider_release(provider);
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     aws_string_destroy(config_file_str);
     s_aws_mock_token_provider_sso_tester_cleanup();
@@ -425,7 +430,8 @@ static int s_sso_token_provider_sso_session_expired_token(struct aws_allocator *
     s_aws_mock_token_provider_sso_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_session_name);
@@ -455,6 +461,8 @@ static int s_sso_token_provider_sso_session_expired_token(struct aws_allocator *
         aws_credentials_provider_get_credentials(provider, aws_test_get_credentials_async_callback, &callback_results));
     aws_credentials_provider_release(provider);
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     aws_string_destroy(config_file_str);
     s_aws_mock_token_provider_sso_tester_cleanup();
@@ -468,7 +476,8 @@ static int s_sso_token_provider_profile_basic_success(struct aws_allocator *allo
     s_aws_mock_token_provider_sso_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_profile_start_url);
@@ -501,6 +510,8 @@ static int s_sso_token_provider_profile_basic_success(struct aws_allocator *allo
     aws_get_credentials_test_callback_result_clean_up(&callback_results);
     aws_credentials_provider_release(provider);
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     aws_string_destroy(config_file_str);
     s_aws_mock_token_provider_sso_tester_cleanup();
@@ -513,7 +524,8 @@ static int s_sso_token_provider_profile_cached_config_file(struct aws_allocator 
     s_aws_mock_token_provider_sso_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_profile_start_url);
@@ -552,6 +564,8 @@ static int s_sso_token_provider_profile_cached_config_file(struct aws_allocator 
     aws_get_credentials_test_callback_result_clean_up(&callback_results);
     aws_credentials_provider_release(provider);
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     aws_string_destroy(config_file_str);
     s_aws_mock_token_provider_sso_tester_cleanup();
@@ -566,7 +580,8 @@ static int s_sso_token_provider_profile_expired_token(struct aws_allocator *allo
     s_aws_mock_token_provider_sso_tester_init(allocator);
 
     /* redirect $HOME */
-    ASSERT_SUCCESS(aws_set_environment_value(s_home_env_var, s_home_env_current_directory));
+    struct aws_string *tmp_home;
+    ASSERT_SUCCESS(aws_create_random_home_directory(allocator, &tmp_home));
 
     /* create token file */
     struct aws_string *token_path = aws_construct_sso_token_path(allocator, s_sso_profile_start_url);
@@ -596,6 +611,8 @@ static int s_sso_token_provider_profile_expired_token(struct aws_allocator *allo
 
     aws_credentials_provider_release(provider);
 
+    aws_directory_delete(tmp_home, true);
+    aws_string_destroy(tmp_home);
     aws_string_destroy(token_path);
     aws_string_destroy(config_file_str);
     s_aws_mock_token_provider_sso_tester_cleanup();


### PR DESCRIPTION
**Issue:**
Rare chance of failure when tests run in parallel.

The issue was that many tests need to write, then read, an SSO token file at `$HOME/.aws/sso/cache/<xyz>.json`. But if multiple tests run in parallel, they could each write different stuff to that file, and then read the contents that some OTHER test put there.

**Description of changes:**
Each test creates a random tmp directory and uses that as `$HOME`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
