### PR TITLE
Handle empty path in `AWS_CONTAINER_CREDENTIALS_FULL_URI`

### DIFF
--- a/source/credentials_provider_default_chain.c
+++ b/source/credentials_provider_default_chain.c
@@ -86,11 +86,16 @@ static struct aws_credentials_provider *s_aws_credentials_provider_new_ecs_or_im
             goto clean_up;
         }
 
+        struct aws_byte_cursor path_and_query = uri.path_and_query;
+        if (path_and_query.len == 0) {
+            path_and_query = aws_byte_cursor_from_c_str("/");
+        }
+
         struct aws_credentials_provider_ecs_options ecs_options = {
             .shutdown_options = *shutdown_options,
             .bootstrap = bootstrap,
             .host = uri.host_name,
-            .path_and_query = uri.path_and_query,
+            .path_and_query = path_and_query,
             .tls_ctx = aws_byte_cursor_eq_c_str_ignore_case(&(uri.scheme), "HTTPS") ? tls_ctx : NULL,
             .auth_token = auth_token_cursor,
             .port = uri.port,


### PR DESCRIPTION
URI paths are allowed to be empty, but for HTTP requests we need to replace empty paths with `/`. This fix allows examples like:

    export AWS_CONTAINER_CREDENTIALS_FULL_URI=http://127.0.0.1:9911

to work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
