### PR TITLE
Make Partial Creds a Transient Error

### DIFF
--- a/source/credentials_provider_profile.c
+++ b/source/credentials_provider_profile.c
@@ -473,12 +473,6 @@ static struct aws_credentials_provider *s_credentials_provider_new_profile_inter
         provider = s_create_sts_based_provider(
             allocator, role_arn_property, profile, options, merged_profiles, source_profiles_table);
     } else {
-        /* fail at creation time if profile contains partial creds */
-        if (!profile_contains_access_key || !profile_contains_secret_access_key) {
-            AWS_LOGF_ERROR(AWS_LS_AUTH_CREDENTIALS_PROVIDER, "Profile contains partial credentials");
-            aws_raise_error(AWS_AUTH_CREDENTIALS_PROVIDER_PROFILE_SOURCE_FAILURE);
-            goto on_finished;
-        }
         provider = s_create_profile_based_provider(
             allocator, credentials_file_path, config_file_path, profile_name, options->profile_collection_cached);
     }

--- a/tests/credentials_provider_sts_tests.c
+++ b/tests/credentials_provider_sts_tests.c
@@ -964,12 +964,17 @@ static int s_credentials_provider_sts_from_profile_config_with_chain_and_partial
     s_tester.mock_response_code = 200;
 
     struct aws_credentials_provider *provider = aws_credentials_provider_new_profile(allocator, &options);
-    ASSERT_NULL(provider);
-    ASSERT_INT_EQUALS(AWS_AUTH_CREDENTIALS_PROVIDER_PROFILE_SOURCE_FAILURE, aws_last_error());
+    ASSERT_NOT_NULL(provider);
 
     aws_string_destroy(config_file_str);
     aws_string_destroy(creds_file_str);
 
+    aws_credentials_provider_get_credentials(provider, s_get_credentials_callback, NULL);
+
+    s_aws_wait_for_credentials_result();
+
+    ASSERT_NULL(s_tester.credentials);
+    ASSERT_INT_EQUALS(s_tester.error_code, AWS_AUTH_SIGNING_NO_CREDENTIALS);
     aws_credentials_provider_release(provider);
 
     ASSERT_SUCCESS(s_aws_sts_tester_cleanup());


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Make partial/missing creds a transient error in the profile credentials provider instead of creation failure to keep it consistent with the previous behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
