### PR TITLE
Additional logging for default credentials chain

### DIFF
--- a/source/credentials_provider_ecs.c
+++ b/source/credentials_provider_ecs.c
@@ -431,6 +431,9 @@ static int s_credentials_provider_ecs_get_credentials_async(
     aws_on_get_credentials_callback_fn callback,
     void *user_data) {
 
+    AWS_LOGF_DEBUG(
+        AWS_LS_AUTH_CREDENTIALS_PROVIDER, "id=%p: ECS provider trying to load credentials", (void *)provider);
+
     struct aws_credentials_provider_ecs_impl *impl = provider->impl;
 
     struct aws_credentials_provider_ecs_user_data *wrapped_user_data =

--- a/source/credentials_provider_environment.c
+++ b/source/credentials_provider_environment.c
@@ -40,6 +40,17 @@ static int s_credentials_provider_environment_get_credentials_async(
         error_code = AWS_AUTH_CREDENTIALS_PROVIDER_INVALID_ENVIRONMENT;
     }
 
+    if (error_code == AWS_ERROR_SUCCESS) {
+        AWS_LOGF_INFO(
+            AWS_LS_AUTH_CREDENTIALS_PROVIDER, "id=%p: Loaded credentials from environment variables", (void *)provider);
+    } else {
+        AWS_LOGF_INFO(
+            AWS_LS_AUTH_CREDENTIALS_PROVIDER,
+            "id=%p: Failed to load credentials from environment variables: %s",
+            (void *)provider,
+            aws_error_str(error_code));
+    }
+
     callback(credentials, error_code, user_data);
 
     aws_credentials_release(credentials);

--- a/source/credentials_provider_imds.c
+++ b/source/credentials_provider_imds.c
@@ -190,6 +190,9 @@ static int s_credentials_provider_imds_get_credentials_async(
     aws_on_get_credentials_callback_fn callback,
     void *user_data) {
 
+    AWS_LOGF_DEBUG(
+        AWS_LS_AUTH_CREDENTIALS_PROVIDER, "id=%p: IMDS provider trying to load credentials", (void *)provider);
+
     struct aws_credentials_provider_imds_impl *impl = provider->impl;
 
     struct imds_provider_user_data *wrapped_user_data = s_imds_provider_user_data_new(provider, callback, user_data);
@@ -201,9 +204,17 @@ static int s_credentials_provider_imds_get_credentials_async(
         goto error;
     }
 
+    AWS_LOGF_INFO(
+        AWS_LS_AUTH_CREDENTIALS_PROVIDER, "id=%p: IMDS provider successfully retrieved credentials", (void *)provider);
+
     return AWS_OP_SUCCESS;
 
 error:
+    AWS_LOGF_ERROR(
+        AWS_LS_AUTH_CREDENTIALS_PROVIDER,
+        "id=%p: IMDS provider failed to retrieve credentials: %s",
+        (void *)provider,
+        aws_error_str(aws_last_error()));
     s_imds_provider_user_data_destroy(wrapped_user_data);
     return AWS_OP_ERR;
 }

--- a/source/credentials_provider_imds.c
+++ b/source/credentials_provider_imds.c
@@ -161,7 +161,7 @@ static void s_on_get_credentials(const struct aws_credentials *credentials, int 
             "id=%p: IMDS provider successfully retrieved credentials",
             (void *)wrapped_user_data->imds_provider);
     } else {
-        AWS_LOGF_ERROR(
+        AWS_LOGF_INFO(
             AWS_LS_AUTH_CREDENTIALS_PROVIDER,
             "id=%p: IMDS provider failed to retrieve credentials: %s",
             (void *)wrapped_user_data->imds_provider,
@@ -192,7 +192,7 @@ static void s_on_get_role(const struct aws_byte_buf *role, int error_code, void 
     return;
 
 on_error:
-    AWS_LOGF_ERROR(
+    AWS_LOGF_INFO(
         AWS_LS_AUTH_CREDENTIALS_PROVIDER,
         "id=%p: IMDS provider failed to retrieve role: %s",
         (void *)wrapped_user_data->imds_provider,

--- a/source/credentials_provider_profile.c
+++ b/source/credentials_provider_profile.c
@@ -137,6 +137,15 @@ static int s_profile_file_credentials_provider_get_credentials_async(
         }
     }
 
+    if (error_code == AWS_ERROR_SUCCESS) {
+        AWS_LOGF_INFO(AWS_LS_AUTH_CREDENTIALS_PROVIDER, "Loaded credentials from profile provider");
+    } else {
+        AWS_LOGF_INFO(
+            AWS_LS_AUTH_CREDENTIALS_PROVIDER,
+            "Failed to load credentials from profile provider: %s",
+            aws_error_str(error_code));
+    }
+
     callback(credentials, error_code, user_data);
 
     /*
@@ -175,9 +184,13 @@ static struct aws_credentials_provider *s_create_profile_based_provider(
     struct aws_string *config_file_path,
     const struct aws_string *profile_name,
     struct aws_profile_collection *profile_collection_cached) {
-
     struct aws_credentials_provider *provider = NULL;
     struct aws_credentials_provider_profile_file_impl *impl = NULL;
+
+    AWS_LOGF_INFO(
+        AWS_LS_AUTH_CREDENTIALS_PROVIDER,
+        "static: profile %s attempting to create profile-based credentials provider",
+        aws_string_c_str(profile_name));
 
     aws_mem_acquire_many(
         allocator,

--- a/source/credentials_provider_sts_web_identity.c
+++ b/source/credentials_provider_sts_web_identity.c
@@ -748,6 +748,11 @@ static int s_credentials_provider_sts_web_identity_get_credentials_async(
 
     struct aws_credentials_provider_sts_web_identity_impl *impl = provider->impl;
 
+    AWS_LOGF_DEBUG(
+        AWS_LS_AUTH_CREDENTIALS_PROVIDER,
+        "id=%p: STS_WEB_IDENTITY provider trying to load credentials",
+        (void *)provider);
+
     struct sts_web_identity_user_data *wrapped_user_data = s_user_data_new(provider, callback, user_data);
     if (wrapped_user_data == NULL) {
         goto error;


### PR DESCRIPTION
We've been finding it difficult to follow the log output of credentials providers when investigating permissions issues. The problem is that the default chain is constructed somewhat dynamically, with some providers only added conditionally, and some dispatching differently depending on environment variables. This patch just adds some more logging in the default chain and in the providers it uses, so we can more easily trace the path of credentials resolution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
