### PR TITLE
Update CacheCredentialsProvider Refresh Time to 5 Minutes before Expiry

### DIFF
--- a/source/credentials_provider_cached.c
+++ b/source/credentials_provider_cached.c
@@ -20,7 +20,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_credential_expiration_env_var, "AWS_CREDENTIAL_
 
 */
 
-#define REFRESH_CREDENTIALS_EARLY_DURATION_SECONDS 10
+#define REFRESH_CREDENTIALS_EARLY_DURATION_SECONDS 60 * 5 /* 5 minutes */
 
 struct aws_credentials_provider_cached {
     struct aws_credentials_provider *source;

--- a/source/credentials_provider_cached.c
+++ b/source/credentials_provider_cached.c
@@ -120,6 +120,8 @@ static void s_cached_credentials_provider_get_credentials_async_callback(
                         AWS_TIMESTAMP_SECS,
                         AWS_TIMESTAMP_NANOS,
                         NULL);
+                } else {
+                    next_refresh_time_in_ns = high_res_now;
                 }
             }
         }

--- a/tests/credentials_provider_sts_tests.c
+++ b/tests/credentials_provider_sts_tests.c
@@ -2091,8 +2091,7 @@ static int s_credentials_provider_sts_cache_expiration_conflict(struct aws_alloc
     ASSERT_TRUE(aws_credentials_get_expiration_timepoint_seconds(s_tester.credentials) == 900);
 
     /* advance each time to after expiration but before cached provider timeout, verify we get new creds */
-    uint64_t after_expiration_time =
-        aws_timestamp_convert(901, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
+    uint64_t after_expiration_time = aws_timestamp_convert(901, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
     mock_aws_set_system_time(after_expiration_time);
     mock_aws_set_high_res_time(HIGH_RES_BASE_TIME_NS + after_expiration_time);
 

--- a/tests/credentials_provider_sts_tests.c
+++ b/tests/credentials_provider_sts_tests.c
@@ -2078,9 +2078,9 @@ static int s_credentials_provider_sts_cache_expiration_conflict(struct aws_alloc
         s_tester.mocked_requests[0].body.len);
 
     /* advance each time to a little before expiration, verify we get creds with the same expiration */
-    uint64_t eight_hundred_seconds_in_ns = aws_timestamp_convert(599, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
-    mock_aws_set_system_time(eight_hundred_seconds_in_ns);
-    mock_aws_set_high_res_time(HIGH_RES_BASE_TIME_NS + eight_hundred_seconds_in_ns);
+    uint64_t before_expiration_time = aws_timestamp_convert(599, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
+    mock_aws_set_system_time(before_expiration_time);
+    mock_aws_set_high_res_time(HIGH_RES_BASE_TIME_NS + before_expiration_time);
 
     s_cleanup_creds_callback_data();
 
@@ -2091,10 +2091,10 @@ static int s_credentials_provider_sts_cache_expiration_conflict(struct aws_alloc
     ASSERT_TRUE(aws_credentials_get_expiration_timepoint_seconds(s_tester.credentials) == 900);
 
     /* advance each time to after expiration but before cached provider timeout, verify we get new creds */
-    uint64_t nine_hundred_and_one_seconds_in_ns =
+    uint64_t after_expiration_time =
         aws_timestamp_convert(901, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
-    mock_aws_set_system_time(nine_hundred_and_one_seconds_in_ns);
-    mock_aws_set_high_res_time(HIGH_RES_BASE_TIME_NS + nine_hundred_and_one_seconds_in_ns);
+    mock_aws_set_system_time(after_expiration_time);
+    mock_aws_set_high_res_time(HIGH_RES_BASE_TIME_NS + after_expiration_time);
 
     s_cleanup_creds_callback_data();
 

--- a/tests/credentials_provider_sts_tests.c
+++ b/tests/credentials_provider_sts_tests.c
@@ -2078,7 +2078,7 @@ static int s_credentials_provider_sts_cache_expiration_conflict(struct aws_alloc
         s_tester.mocked_requests[0].body.len);
 
     /* advance each time to a little before expiration, verify we get creds with the same expiration */
-    uint64_t eight_hundred_seconds_in_ns = aws_timestamp_convert(800, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
+    uint64_t eight_hundred_seconds_in_ns = aws_timestamp_convert(599, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
     mock_aws_set_system_time(eight_hundred_seconds_in_ns);
     mock_aws_set_high_res_time(HIGH_RES_BASE_TIME_NS + eight_hundred_seconds_in_ns);
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- 10 seconds is too low because the recommended guidance is at least 5 minutes (https://repost.aws/questions/QUgE4lrlyBSimJZTpIO9o7Hw/the-provided-token-has-expired-aws-rds-with-s3), and the other SDKs also have at least 5-minute refresh timers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
