### PR TITLE
Add account id

### DIFF
--- a/include/aws/auth/credentials.h
+++ b/include/aws/auth/credentials.h
@@ -82,6 +82,7 @@ struct aws_credentials_provider_static_options {
     struct aws_byte_cursor access_key_id;
     struct aws_byte_cursor secret_access_key;
     struct aws_byte_cursor session_token;
+    struct aws_byte_cursor account_id;
 };
 
 /**
@@ -744,6 +745,28 @@ struct aws_credentials *aws_credentials_new(
     uint64_t expiration_timepoint_seconds);
 
 /**
+ * Creates a new set of aws credentials with account_id
+ *
+ * @param allocator memory allocator to use
+ * @param access_key_id_cursor value for the aws access key id field
+ * @param secret_access_key_cursor value for the secret access key field
+ * @param session_token_cursor (optional) security token associated with the credentials
+ * @param account_id value for the account_id field
+ * @param expiration_timepoint_seconds timepoint, in seconds since epoch, that the credentials will no longer
+ * be valid past.  For credentials that do not expire, use UINT64_MAX
+ *
+ * @return a valid credentials object, or NULL
+ */
+AWS_AUTH_API
+struct aws_credentials *aws_credentials_new_with_account_id(
+    struct aws_allocator *allocator,
+    struct aws_byte_cursor access_key_id_cursor,
+    struct aws_byte_cursor secret_access_key_cursor,
+    struct aws_byte_cursor session_token_cursor,
+    struct aws_byte_cursor account_id_cursor,
+    uint64_t expiration_timepoint_seconds);
+
+/**
  * Creates a new set of aws anonymous credentials.
  * Use Anonymous credentials, when you want to skip the signing process.
  *
@@ -847,6 +870,15 @@ struct aws_byte_cursor aws_credentials_get_secret_access_key(const struct aws_cr
  */
 AWS_AUTH_API
 struct aws_byte_cursor aws_credentials_get_session_token(const struct aws_credentials *credentials);
+
+/**
+ * Get the AWS account id from a set of credentials
+ *
+ * @param credentials to get the account id from
+ * @return a byte cursor to the account id or an empty byte cursor if there is no account id
+ */
+AWS_AUTH_API
+struct aws_byte_cursor aws_credentials_get_account_id(const struct aws_credentials *credentials);
 
 /**
  * Get the expiration timepoint (in seconds since epoch) associated with a set of credentials

--- a/source/credentials.c
+++ b/source/credentials.c
@@ -22,6 +22,7 @@ struct aws_credentials_identity {
     struct aws_string *access_key_id;
     struct aws_string *secret_access_key;
     struct aws_string *session_token;
+    struct aws_string *account_id;
 };
 
 /* aws_token identity contains only a token to represent token only identities like a bearer token. */
@@ -92,6 +93,25 @@ struct aws_credentials *aws_credentials_new(
     struct aws_byte_cursor session_token_cursor,
     uint64_t expiration_timepoint_seconds) {
 
+    struct aws_byte_cursor account_id;
+    AWS_ZERO_STRUCT(account_id);
+
+    return aws_credentials_new_with_account_id(
+        allocator,
+        access_key_id_cursor,
+        secret_access_key_cursor,
+        session_token_cursor,
+        account_id,
+        expiration_timepoint_seconds);
+}
+struct aws_credentials *aws_credentials_new_with_account_id(
+    struct aws_allocator *allocator,
+    struct aws_byte_cursor access_key_id_cursor,
+    struct aws_byte_cursor secret_access_key_cursor,
+    struct aws_byte_cursor session_token_cursor,
+    struct aws_byte_cursor account_id_cursor,
+    uint64_t expiration_timepoint_seconds) {
+
     if (access_key_id_cursor.ptr == NULL || access_key_id_cursor.len == 0) {
         aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         return NULL;
@@ -133,6 +153,14 @@ struct aws_credentials *aws_credentials_new(
         }
     }
 
+    if (account_id_cursor.ptr != NULL && account_id_cursor.len > 0) {
+        credentials_identity->account_id =
+            aws_string_new_from_array(allocator, account_id_cursor.ptr, account_id_cursor.len);
+        if (credentials_identity->account_id == NULL) {
+            goto error;
+        }
+    }
+
     credentials->expiration_timepoint_seconds = expiration_timepoint_seconds;
 
     return credentials;
@@ -166,6 +194,7 @@ static void s_aws_credentials_destroy(struct aws_credentials *credentials) {
             aws_string_destroy(credentials->identity.credentials_identity.access_key_id);
             aws_string_destroy_secure(credentials->identity.credentials_identity.secret_access_key);
             aws_string_destroy_secure(credentials->identity.credentials_identity.session_token);
+            aws_string_destroy_secure(credentials->identity.credentials_identity.account_id);
             break;
         case ECC_IDENTITY:
             aws_string_destroy(credentials->identity.ecc_identity.access_key_id);
@@ -247,6 +276,19 @@ struct aws_byte_cursor aws_credentials_get_session_token(const struct aws_creden
         case ECC_IDENTITY:
             if (credentials->identity.ecc_identity.session_token != NULL) {
                 return aws_byte_cursor_from_string(credentials->identity.ecc_identity.session_token);
+            }
+            break;
+        default:
+            break;
+    }
+    return s_empty_token_cursor;
+}
+
+struct aws_byte_cursor aws_credentials_get_account_id(const struct aws_credentials *credentials) {
+    switch (credentials->identity_type) {
+        case AWS_CREDENTIALS_IDENTITY:
+            if (credentials->identity.credentials_identity.account_id != NULL) {
+                return aws_byte_cursor_from_string(credentials->identity.credentials_identity.account_id);
             }
             break;
         default:

--- a/source/credentials_provider_static.c
+++ b/source/credentials_provider_static.c
@@ -51,8 +51,13 @@ struct aws_credentials_provider *aws_credentials_provider_new_static(
 
     AWS_ZERO_STRUCT(*provider);
 
-    struct aws_credentials *credentials = aws_credentials_new(
-        allocator, options->access_key_id, options->secret_access_key, options->session_token, UINT64_MAX);
+    struct aws_credentials *credentials = aws_credentials_new_with_account_id(
+        allocator,
+        options->access_key_id,
+        options->secret_access_key,
+        options->session_token,
+        options->account_id,
+        UINT64_MAX);
     if (credentials == NULL) {
         goto on_new_credentials_failure;
     }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-crt-swift/issues/303

*Description of changes:*
- Adds a new optional account_id field to credentials. Currently, only static credentials support it, but soon we will add account_id for SSO, STS, and any other providers that can provide it.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
