### PR TITLE
make exports consistent

### DIFF
--- a/include/aws/auth/exports.h
+++ b/include/aws/auth/exports.h
@@ -6,7 +6,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#if defined(USE_WINDOWS_DLL_SEMANTICS) || defined(WIN32)
+#if defined(AWS_CRT_USE_WINDOWS_DLL_SEMANTICS) || defined(_WIN32)
 #    ifdef AWS_AUTH_USE_IMPORT_EXPORT
 #        ifdef AWS_AUTH_EXPORTS
 #            define AWS_AUTH_API __declspec(dllexport)
@@ -18,12 +18,12 @@
 #    endif /*USE_IMPORT_EXPORT */
 
 #else
-#    if ((__GNUC__ >= 4) || defined(__clang__)) && defined(AWS_AUTH_USE_IMPORT_EXPORT) && defined(AWS_AUTH_EXPORTS)
+#    if defined(AWS_AUTH_USE_IMPORT_EXPORT) && defined(AWS_AUTH_EXPORTS)
 #        define AWS_AUTH_API __attribute__((visibility("default")))
 #    else
 #        define AWS_AUTH_API
 #    endif /* __GNUC__ >= 4 || defined(__clang__) */
 
-#endif /* defined(USE_WINDOWS_DLL_SEMANTICS) || defined(WIN32) */
+#endif /* defined(AWS_CRT_USE_WINDOWS_DLL_SEMANTICS) || defined(_WIN32) */
 
 #endif /* AWS_AUTH_EXPORTS_H */

--- a/include/aws/auth/exports.h
+++ b/include/aws/auth/exports.h
@@ -22,7 +22,7 @@
 #        define AWS_AUTH_API __attribute__((visibility("default")))
 #    else
 #        define AWS_AUTH_API
-#    endif /* __GNUC__ >= 4 || defined(__clang__) */
+#    endif
 
 #endif /* defined(AWS_CRT_USE_WINDOWS_DLL_SEMANTICS) || defined(_WIN32) */
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
make AWS_CRT_USE_WINDOWS_DLL_SEMANTICS the variable for forcing win semantics
remove gcc < 4

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
