### PR TITLE
Fix warnings found by the Undefined Behavior Sanitizer

### DIFF
--- a/source/aws_signing.c
+++ b/source/aws_signing.c
@@ -100,6 +100,12 @@ static struct aws_byte_cursor s_amz_security_token_param_name;
 static struct aws_byte_cursor s_amz_expires_param_name;
 static struct aws_byte_cursor s_amz_region_set_param_name;
 
+static bool s_name_eq_ignore_case(const void *a, const void *b) {
+    const struct aws_byte_cursor *a_cursor = a;
+    const struct aws_byte_cursor *b_cursor = b;
+    return aws_byte_cursor_eq_ignore_case(a_cursor, b_cursor);
+}
+
 /*
  * Build a set of library-static tables for quick lookup.
  *
@@ -112,7 +118,7 @@ int aws_signing_init_signing_tables(struct aws_allocator *allocator) {
             allocator,
             10,
             aws_hash_byte_cursor_ptr_ignore_case,
-            (aws_hash_callback_eq_fn *)aws_byte_cursor_eq_ignore_case,
+            s_name_eq_ignore_case,
             NULL,
             NULL)) {
         return AWS_OP_ERR;
@@ -168,7 +174,7 @@ int aws_signing_init_signing_tables(struct aws_allocator *allocator) {
             allocator,
             10,
             aws_hash_byte_cursor_ptr_ignore_case,
-            (aws_hash_callback_eq_fn *)aws_byte_cursor_eq_ignore_case,
+            s_name_eq_ignore_case,
             NULL,
             NULL)) {
         return AWS_OP_ERR;
@@ -207,7 +213,7 @@ int aws_signing_init_signing_tables(struct aws_allocator *allocator) {
             allocator,
             10,
             aws_hash_byte_cursor_ptr_ignore_case,
-            (aws_hash_callback_eq_fn *)aws_byte_cursor_eq_ignore_case,
+            s_name_eq_ignore_case,
             NULL,
             NULL)) {
         return AWS_OP_ERR;


### PR DESCRIPTION
Fixes runtime error warnings found when running the tests with the undefined behavior sanitizer enabled.

```
grep "runtime error" aws-c-auth/build/Testing/Temporary/LastTest.log

aws-c-common/source/hash_table.c:68:16: runtime error: call to function aws_byte_cursor_eq through pointer to incorrect function type 'bool (*)(const void *, const void *)'
...
```
*Description of changes:*
Add a callback function that uses correct signature [aws_hash_callback_eq_fn](https://github.com/awslabs/aws-c-common/blob/cde20c682d46ed8ee03ab6412c3f386f5dbdd0c7/include/aws/common/hash_table.h#L110)  (as seen in [aws-c-mqtt](https://github.com/awslabs/aws-c-mqtt/blob/f9aefbc95e63d00eada405fc4d69b2087cbc06de/source/client_impl_shared.c#L220)).

Since the CI-build is not using `-fno-sanitize-recover=all`, and the warnings are recoverable they will not fail the CI build.
The warnings are also found when a user incorporates `aws-sdk-cpp` into a project and build it using an UB sanitizer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
