### PR TITLE
Fix sts_web_identity credentials provider

### DIFF
--- a/source/credentials_provider_sts_web_identity.c
+++ b/source/credentials_provider_sts_web_identity.c
@@ -527,9 +527,7 @@ static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_co
     struct sts_web_identity_user_data *user_data = data;
 
     struct aws_credentials_provider_sts_web_identity_impl *impl = user_data->sts_web_identity_provider->impl;
-    struct aws_http_connection *connection = impl->function_table->aws_http_stream_get_connection(stream);
     impl->function_table->aws_http_stream_release(stream);
-    impl->function_table->aws_http_connection_manager_release_connection(impl->connection_manager, connection);
 
     /*
      * On anything other than a 200, if we can retry the request based on

--- a/source/credentials_provider_sts_web_identity.c
+++ b/source/credentials_provider_sts_web_identity.c
@@ -527,7 +527,9 @@ static void s_on_stream_complete_fn(struct aws_http_stream *stream, int error_co
     struct sts_web_identity_user_data *user_data = data;
 
     struct aws_credentials_provider_sts_web_identity_impl *impl = user_data->sts_web_identity_provider->impl;
+    struct aws_http_connection *connection = impl->function_table->aws_http_stream_get_connection(stream);
     impl->function_table->aws_http_stream_release(stream);
+    impl->function_table->aws_http_connection_manager_release_connection(impl->connection_manager, connection);
 
     /*
      * On anything other than a 200, if we can retry the request based on

--- a/tests/credentials_provider_sts_web_identity_tests.c
+++ b/tests/credentials_provider_sts_web_identity_tests.c
@@ -98,8 +98,9 @@ static void s_aws_http_connection_manager_acquire_connection_mock(
     aws_http_connection_manager_on_connection_setup_fn *callback,
     void *user_data) {
     struct mock_connection_manager *mock_manager = (struct mock_connection_manager *)manager;
-    mock_manager->count++;
+
     if (s_tester.is_connection_acquire_successful) {
+        mock_manager->count++;
         callback((struct aws_http_connection *)1, AWS_OP_SUCCESS, user_data);
     } else {
         aws_raise_error(AWS_ERROR_HTTP_UNKNOWN);

--- a/tests/credentials_provider_sts_web_identity_tests.c
+++ b/tests/credentials_provider_sts_web_identity_tests.c
@@ -88,7 +88,7 @@ static struct aws_http_connection_manager *s_aws_http_connection_manager_new_moc
 
 static void s_aws_http_connection_manager_release_mock(struct aws_http_connection_manager *manager) {
     struct mock_connection_manager *mock_manager = (struct mock_connection_manager *)manager;
-    AWS_ASSERT(mock_manager->count == 0 && "count should dropped to zero when the manager is gone.");
+    AWS_FATAL_ASSERT(mock_manager->count == 0 && "count should dropped to zero when the manager is gone.");
     mock_manager->shutdown_complete_callback(mock_manager->shutdown_complete_user_data);
     aws_mem_release(mock_manager->allocator, mock_manager);
 }
@@ -113,9 +113,9 @@ static int s_aws_http_connection_manager_release_connection_mock(
 
     struct mock_connection_manager *mock_manager = (struct mock_connection_manager *)manager;
     mock_manager->count--;
-    AWS_ASSERT(
+    ASSERT_TRUE(
         connection == (struct aws_http_connection *)1 && "the released connection should be the same as vended one");
-    AWS_ASSERT(mock_manager->count >= 0 && "count should always be positive");
+    ASSERT_TRUE(mock_manager->count >= 0 && "count should always be positive");
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/credentials_provider_sts_web_identity_tests.c
+++ b/tests/credentials_provider_sts_web_identity_tests.c
@@ -71,6 +71,8 @@ struct mock_connection_manager {
     struct aws_allocator *allocator;
     aws_http_connection_manager_shutdown_complete_fn *shutdown_complete_callback;
     void *shutdown_complete_user_data;
+
+    int count;
 };
 
 static struct aws_http_connection_manager *s_aws_http_connection_manager_new_mock(
@@ -86,6 +88,7 @@ static struct aws_http_connection_manager *s_aws_http_connection_manager_new_moc
 
 static void s_aws_http_connection_manager_release_mock(struct aws_http_connection_manager *manager) {
     struct mock_connection_manager *mock_manager = (struct mock_connection_manager *)manager;
+    AWS_ASSERT(mock_manager->count == 0 && "count should dropped to zero when the manager is gone.");
     mock_manager->shutdown_complete_callback(mock_manager->shutdown_complete_user_data);
     aws_mem_release(mock_manager->allocator, mock_manager);
 }
@@ -94,11 +97,8 @@ static void s_aws_http_connection_manager_acquire_connection_mock(
     struct aws_http_connection_manager *manager,
     aws_http_connection_manager_on_connection_setup_fn *callback,
     void *user_data) {
-
-    (void)manager;
-    (void)callback;
-    (void)user_data;
-
+    struct mock_connection_manager *mock_manager = (struct mock_connection_manager *)manager;
+    mock_manager->count++;
     if (s_tester.is_connection_acquire_successful) {
         callback((struct aws_http_connection *)1, AWS_OP_SUCCESS, user_data);
     } else {
@@ -111,8 +111,11 @@ static int s_aws_http_connection_manager_release_connection_mock(
     struct aws_http_connection_manager *manager,
     struct aws_http_connection *connection) {
 
-    (void)manager;
-    (void)connection;
+    struct mock_connection_manager *mock_manager = (struct mock_connection_manager *)manager;
+    mock_manager->count--;
+    AWS_ASSERT(
+        connection == (struct aws_http_connection *)1 && "the released connection should be the same as vended one");
+    AWS_ASSERT(mock_manager->count >= 0 && "count should always be positive");
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
*Issue #, if available:*

- The sts_web_identity double frees the connection to connection manager. And causes a fatal warning and should be an error. But looks like nothing in code actually makes it to fail.

*Description of changes:*
- Add a count in the mock connection manager to make sure those connection are acquired and released correctly


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
