### PR TITLE
fix: Remove strict requirement for ECS SessionToken

### DIFF
--- a/source/credentials_provider_ecs.c
+++ b/source/credentials_provider_ecs.c
@@ -190,7 +190,7 @@ static void s_ecs_finalize_get_credentials_query(struct aws_credentials_provider
         .token_name = "Token",
         .account_id_name = "AccountId",
         .expiration_name = "Expiration",
-        .token_required = true,
+        .token_required = false,
         .expiration_required = true,
     };
     if (aws_byte_buf_append_null_terminator(&ecs_user_data->current_result) == AWS_OP_SUCCESS) {


### PR DESCRIPTION
I discovered that this library handles the `Token` field in the ECS authentication responses slightly differently than the other AWS SDKs do by checking that the Token is non-empty. The example JSON response in the code is this

```json
 {
  "Code" : "Success",
  "LastUpdated" : "2019-05-28T18:03:09Z",
  "Type" : "AWS-HMAC",
  "AccessKeyId" : "...",
  "SecretAccessKey" : "...",
  "Token" : "...",
  "Expiration" : "2019-05-29T00:21:43Z"
 }
```

However the `Token` / SessionToken is actually optional in the response with some systems where only the ACCESS_KEY and SECRET_KEY are used. By removing this constraint, the authentication works with more systems