### PR TITLE
Fix error handling for profile provider

### DIFF
--- a/source/credentials_provider_profile.c
+++ b/source/credentials_provider_profile.c
@@ -134,10 +134,7 @@ static int s_profile_file_credentials_provider_get_credentials_async(
 
     int error_code = AWS_ERROR_SUCCESS;
     if (credentials == NULL) {
-        error_code = aws_last_error();
-        if (error_code == AWS_ERROR_SUCCESS) {
-            error_code = AWS_AUTH_CREDENTIALS_PROVIDER_PROFILE_SOURCE_FAILURE;
-        }
+        error_code = AWS_AUTH_CREDENTIALS_PROVIDER_PROFILE_SOURCE_FAILURE;
     }
 
     if (error_code == AWS_ERROR_SUCCESS) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
none of our cred constructors currently set error when returning null (which we should probably fix). but our profile cred provider checks error when cred is null, which in practice means that it can pick up random errors on the stack. remove that extra code for now and treat it as the same error.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
