### PR TITLE
Add thread sanitizer CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,3 +213,19 @@ jobs:
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build downstream -p ${{ env.PACKAGE_NAME }}
+
+  clang-sanitizers:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizers: [",thread", ",address,undefined"]
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.CRT_CI_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Build ${{ env.PACKAGE_NAME }}
+        run: |
+          aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
+          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-11 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,12 +214,8 @@ jobs:
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build downstream -p ${{ env.PACKAGE_NAME }}
 
-  clang-sanitizers:
+  clang-thread-sanitizer:
     runs-on: ubuntu-24.04
-    strategy:
-      fail-fast: false
-      matrix:
-        sanitizers: [",thread", ",address,undefined"]
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:
@@ -228,4 +224,4 @@ jobs:
       - name: Build ${{ env.PACKAGE_NAME }}
         run: |
           aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-11 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
+          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=clang-11 --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS=",thread"

--- a/tests/aws_imds_client_test.c
+++ b/tests/aws_imds_client_test.c
@@ -66,9 +66,8 @@ static void s_on_shutdown_complete(void *user_data) {
 
     aws_mutex_lock(&s_tester.lock);
     s_tester.has_received_shutdown_callback = true;
-    aws_mutex_unlock(&s_tester.lock);
-
     aws_condition_variable_notify_one(&s_tester.signal);
+    aws_mutex_unlock(&s_tester.lock);
 }
 
 static bool s_has_tester_received_shutdown_callback(void *user_data) {

--- a/tests/credentials_provider_ecs_tests.c
+++ b/tests/credentials_provider_ecs_tests.c
@@ -69,9 +69,8 @@ static void s_on_shutdown_complete(void *user_data) {
 
     aws_mutex_lock(&s_tester.lock);
     s_tester.has_received_shutdown_callback = true;
-    aws_mutex_unlock(&s_tester.lock);
-
     aws_condition_variable_notify_one(&s_tester.signal);
+    aws_mutex_unlock(&s_tester.lock);
 }
 
 static bool s_has_tester_received_shutdown_callback(void *user_data) {

--- a/tests/credentials_provider_imds_tests.c
+++ b/tests/credentials_provider_imds_tests.c
@@ -83,9 +83,8 @@ static void s_on_shutdown_complete(void *user_data) {
 
     aws_mutex_lock(&s_tester.lock);
     s_tester.has_received_shutdown_callback = true;
-    aws_mutex_unlock(&s_tester.lock);
-
     aws_condition_variable_notify_one(&s_tester.signal);
+    aws_mutex_unlock(&s_tester.lock);
 }
 
 static bool s_has_tester_received_shutdown_callback(void *user_data) {

--- a/tests/credentials_provider_process_tests.c
+++ b/tests/credentials_provider_process_tests.c
@@ -30,9 +30,8 @@ static void s_on_shutdown_complete(void *user_data) {
 
     aws_mutex_lock(&s_tester.lock);
     s_tester.has_received_shutdown_callback = true;
-    aws_mutex_unlock(&s_tester.lock);
-
     aws_condition_variable_notify_one(&s_tester.signal);
+    aws_mutex_unlock(&s_tester.lock);
 }
 
 static bool s_has_tester_received_shutdown_callback(void *user_data) {

--- a/tests/credentials_provider_sts_tests.c
+++ b/tests/credentials_provider_sts_tests.c
@@ -78,9 +78,8 @@ static void s_on_connection_manager_shutdown_complete(void *user_data) {
 
     aws_mutex_lock(&s_tester.lock);
     s_tester.mocked_connection_manager_shutdown_callback_count++;
-    aws_mutex_unlock(&s_tester.lock);
-
     aws_condition_variable_notify_one(&s_tester.signal);
+    aws_mutex_unlock(&s_tester.lock);
 }
 
 static bool s_has_tester_received_connection_manager_shutdown_callback(void *user_data) {
@@ -102,9 +101,8 @@ static void s_on_provider_shutdown(void *user_data) {
 
     aws_mutex_lock(&s_tester.lock);
     s_tester.provider_shutdown_callback_count++;
-    aws_mutex_unlock(&s_tester.lock);
-
     aws_condition_variable_notify_one(&s_tester.signal);
+    aws_mutex_unlock(&s_tester.lock);
 }
 
 static bool s_has_tester_received_provider_shutdown_callback(void *user_data) {

--- a/tests/credentials_provider_sts_web_identity_tests.c
+++ b/tests/credentials_provider_sts_web_identity_tests.c
@@ -52,9 +52,8 @@ static void s_on_shutdown_complete(void *user_data) {
 
     aws_mutex_lock(&s_tester.lock);
     s_tester.has_received_shutdown_callback = true;
-    aws_mutex_unlock(&s_tester.lock);
-
     aws_condition_variable_notify_one(&s_tester.signal);
+    aws_mutex_unlock(&s_tester.lock);
 }
 
 static bool s_has_tester_received_shutdown_callback(void *user_data) {

--- a/tests/credentials_provider_utils.c
+++ b/tests/credentials_provider_utils.c
@@ -614,9 +614,8 @@ void aws_credentials_provider_http_mock_on_shutdown_complete(void *user_data) {
     (void)user_data;
     aws_mutex_lock(&credentials_provider_http_mock_tester.lock);
     credentials_provider_http_mock_tester.has_received_shutdown_callback = true;
-    aws_mutex_unlock(&credentials_provider_http_mock_tester.lock);
-
     aws_condition_variable_notify_one(&credentials_provider_http_mock_tester.signal);
+    aws_mutex_unlock(&credentials_provider_http_mock_tester.lock);
 }
 
 bool aws_credentials_provider_http_mock_has_received_shutdown_callback(void *user_data) {

--- a/tests/credentials_provider_x509_tests.c
+++ b/tests/credentials_provider_x509_tests.c
@@ -48,9 +48,8 @@ static void s_on_shutdown_complete(void *user_data) {
 
     aws_mutex_lock(&s_tester.lock);
     s_tester.has_received_shutdown_callback = true;
-    aws_mutex_unlock(&s_tester.lock);
-
     aws_condition_variable_notify_one(&s_tester.signal);
+    aws_mutex_unlock(&s_tester.lock);
 }
 
 static bool s_has_tester_received_shutdown_callback(void *user_data) {

--- a/tests/credentials_tests.c
+++ b/tests/credentials_tests.c
@@ -91,9 +91,8 @@ static void s_on_shutdown_complete(void *user_data) {
 
     aws_mutex_lock(&s_shutdown_checker.lock);
     s_shutdown_checker.is_shutdown_complete = true;
-    aws_mutex_unlock(&s_shutdown_checker.lock);
-
     aws_condition_variable_notify_one(&s_shutdown_checker.signal);
+    aws_mutex_unlock(&s_shutdown_checker.lock);
 }
 
 static bool s_has_tester_received_shutdown_callback(void *user_data) {


### PR DESCRIPTION
aws-crt-builder enables asan for Linux and macOS by default, so add only tsan.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
